### PR TITLE
No Zero constructor

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ ghc-options:
 library:
   dependencies:
     - base
+    - ghc-prim  # GHC.Types (Constraint)
     - distributive
     - adjunctions
   other-modules: []

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -22,7 +22,8 @@ type (:*)  = (,)
 unzip :: Functor f => f (a :* b) -> f a :* f b
 unzip ps = (fst <$> ps, snd <$> ps)
 
-type V f = ((Representable f, Foldable f, Eq (Rep f), HasZA f, HasZB f) :: Constraint)
+type V f = ((Representable f, Foldable f, Eq (Rep f), HasZA f, HasZB f)
+            :: Constraint)
 type V2 f g = (V f, V g)
 type V3 f g h = (V2 f g, V h)
 type V4 f g h k = (V2 f g, V2 h k)
@@ -221,7 +222,8 @@ exs = unforkL idL
 -- Note that idL == joinL ins == forkL exs
 
 -- Binary biproduct bifunctor
-(***) :: (V4 a b c d, Additive s) => L a c s -> L b d s -> L (a :*: b) (c :*: d) s
+(***) :: (V4 a b c d, Additive s)
+      => L a c s -> L b d s -> L (a :*: b) (c :*: d) s
 f *** g = (f :|# zero) :&# (zero :|# g)
 
 -- N-ary biproduct bifunctor

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -250,12 +250,16 @@ class HasZA a where zeroJ :: Additive s => L a Par1 s
 class HasZB b where zeroF :: (HasZA a, V a, Additive s) => L a b s
 
 instance HasZA Par1 where zeroJ = Scale zero
-instance (HasZA a, HasZA a', V2 a a') => HasZA (a :*: a') where zeroJ = zeroJ :| zeroJ
-instance (HasZA a, V c, V a) => HasZA (c :.: a) where zeroJ = JoinL (pureRep zeroJ)
+instance (HasZA a, HasZA a', V2 a a') => HasZA (a :*: a') where
+  zeroJ = zeroJ :| zeroJ
+instance (HasZA a, V c, V a) => HasZA (c :.: a) where
+  zeroJ = JoinL (pureRep zeroJ)
 
 instance HasZB Par1 where zeroF = zeroJ
-instance (HasZB b, HasZB b', V2 b b') => HasZB (b :*: b') where zeroF = zeroF :& zeroF
-instance (HasZB b, V c, V b) => HasZB (c :.: b) where zeroF = ForkL (pureRep zeroF)
+instance (HasZB b, HasZB b', V2 b b') => HasZB (b :*: b') where
+  zeroF = zeroF :& zeroF
+instance (HasZB b, V c, V b) => HasZB (c :.: b) where
+  zeroF = ForkL (pureRep zeroF)
 
 -- Illegal nested constraint ‘Eq (Rep c)’
 -- (Use UndecidableInstances to permit this)

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -50,7 +50,7 @@ infixr 2 :|#
 -- | Compositional Linear map representation. @L f g s@ denotes @f s -* g s@,
 -- where @(-*)@ means linear functions.
 data L :: (* -> *) -> (* -> *) -> (* -> *) where
-  Zero :: L f g s
+  -- Zero :: L f g s
   Scale :: s -> L Par1 Par1 s
   (:|#) :: L f h s -> L g h s -> L (f :*: g) h s
   (:&#) :: L f h s -> L f k s -> L f (h :*: k) s
@@ -72,7 +72,7 @@ instance (HasScaleV a, HasScaleV b, Representable b) => HasScaleV (b :.: a) wher
   scaleV s = cross (pureRep (scaleV s))
 
 unjoin2 :: Additive s => L (f :*: g) h s -> L f h s :* L g h s
-unjoin2 Zero = (zero,zero)
+-- unjoin2 Zero = (zero,zero)
 unjoin2 (p :|# q) = (p,q)
 unjoin2 ((unjoin2 -> (p,q)) :&# (unjoin2 -> (r,s))) = (p :& r, q :& s)
 unjoin2 (ForkL ms) = (ForkL A.*** ForkL) (unzip (unjoin2 <$> ms))
@@ -92,7 +92,7 @@ unjoin2 (ForkL ms) = (ForkL A.*** ForkL) (unzip (unjoin2 <$> ms))
 #endif
 
 unfork2 :: Additive s => L f (h :*: k) s -> L f h s :* L f k s
-unfork2 Zero = (zero,zero)
+-- unfork2 Zero = (zero,zero)
 unfork2 (p :&# q) = (p,q)
 unfork2 ((unfork2 -> (p,q)) :|# (unfork2 -> (r,s))) = (p :|# r, q :|# s)
 unfork2 (JoinL ms) = (JoinL A.*** JoinL) (unzip (unfork2 <$> ms))
@@ -112,7 +112,7 @@ pattern u :| v <- (unjoin2 -> (u,v)) where (:|) = (:|#)
 -- {-# complete Join #-}
 
 unforkL :: Representable h => L f (h :.: g) s -> h (L f g s)
-unforkL Zero       = pureRep Zero
+-- unforkL Zero       = pureRep Zero
 unforkL (p :|# q)  = liftR2 (:|#) (unforkL p) (unforkL q)
 unforkL (ForkL ms) = ms
 unforkL (JoinL ms) = JoinL <$> distribute (unforkL <$> ms)
@@ -137,7 +137,7 @@ JoinL <$> distrib (unforkL <$> ms) :: h (L (k :.: f) g s)
 #endif
 
 unjoinL :: Representable h => L (h :.: f) g s -> h (L f g s)
-unjoinL Zero       = pureRep Zero
+-- unjoinL Zero       = pureRep Zero
 unjoinL (p :&# p') = liftR2 (:&#) (unjoinL p) (unjoinL p')
 unjoinL (JoinL ms) = ms
 unjoinL (ForkL ms) = fmap ForkL (distribute (fmap unjoinL ms))
@@ -151,9 +151,9 @@ pattern Join ms <- (unjoinL -> ms) where Join = JoinL
 {-# complete Join #-}
 
 instance Additive s => Additive (L f g s) where
-  zero = Zero
-  Zero + m = m
-  m + Zero = m
+  zero = zeroL
+  -- Zero + m = m
+  -- m + Zero = m
   Scale s + Scale s' = Scale (s + s') -- distributivity
   (f :|# g) + (h :| k) = (f + h) :| (g + k)
   (f :&# g) + (h :& k) = (f + h) :& (g + k)
@@ -177,8 +177,8 @@ idL = scaleV one
 
 infixr 9 .@
 (.@) :: Semiring s => L g h s -> L f g s -> L f h s
-Zero      .@ _         = Zero                      -- Zero denotation
-_         .@ Zero      = Zero                      -- linearity
+-- Zero      .@ _         = Zero                      -- Zero denotation
+-- _         .@ Zero      = Zero                      -- linearity
 Scale a   .@ Scale b   = Scale (a * b)             -- Scale denotation
 (p :&# q) .@ m         = (p .@ m) :&# (q .@ m)     -- binary product law
 m         .@ (p :|# q) = (m .@ p) :|# (m .@ q)     -- binary coproduct law
@@ -224,7 +224,7 @@ exs = unforkL idL
 
 -- Binary biproduct bifunctor
 (***) :: L a c s -> L b d s -> L (a :*: b) (c :*: d) s
-f *** g = (f :|# Zero) :&# (Zero :|# g)
+f *** g = (f :|# zero) :&# (zero :|# g)
 
 -- N-ary biproduct bifunctor
 cross :: (V c, Additive s) => c (L a b s) -> L (c :.: a) (c :.: b) s
@@ -232,8 +232,8 @@ cross = JoinL . fmap ForkL . diagRep zero
 
 {- Note that
 
-f *** g == (f :|# Zero) :&# (Zero :|# g)
-        == (f :&# Zero) :|# (Zero :&# g)
+f *** g == (f :|# zero) :&# (zero :|# g)
+        == (f :&# zero) :|# (zero :&# g)
         == (f .@ exl) :&# (g .@ exr)
         == (inl .@ f) :|# (inr .@ g)
 

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -222,7 +222,7 @@ exs = unforkL idL
 
 -- Binary biproduct bifunctor
 (***) :: (V4 a b c d, Additive s) => L a c s -> L b d s -> L (a :*: b) (c :*: d) s
-f *** g = (f :|# zeroL) :&# (zeroL :|# g)
+f *** g = (f :|# zero) :&# (zero :|# g)
 
 -- N-ary biproduct bifunctor
 cross :: (V3 a b c, Additive s) => c (L a b s) -> L (c :.: a) (c :.: b) s
@@ -243,6 +243,8 @@ cross fs == JoinL (ins .^ fs)
 -- The zero linear map
 zeroL :: (V2 a b, Additive s) => L a b s
 zeroL = zeroF
+
+-- zeroL has a tidier ":i" signature than zeroF
 
 class HasZA a where zeroJ :: Additive s => L a Par1 s
 class HasZB b where zeroF :: (HasZA a, V a, Additive s) => L a b s

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -80,7 +80,7 @@ unjoin2 (ForkL ms) = (ForkL A.*** ForkL) (unzip (unjoin2 <$> ms))
 (ForkL *** ForkL) (unzip (unjoin <$> ms)) :: L f (k :.: h) s :* L g (k :.: h) s
 #endif
 
-unfork2 :: (V3 f h k, Additive s) => L f (h :*: k) s -> L f h s :* L f k s
+unfork2 :: V3 f h k => L f (h :*: k) s -> L f h s :* L f k s
 unfork2 (p :&# q) = (p,q)
 unfork2 ((unfork2 -> (p,q)) :|# (unfork2 -> (r,s))) = (p :|# r, q :|# s)
 unfork2 (JoinL ms) = (JoinL A.*** JoinL) (unzip (unfork2 <$> ms))
@@ -94,10 +94,6 @@ pattern u :& v <- (unfork2 -> (u,v)) where (:&) = (:&#)
 pattern (:|) :: (V3 f g h, Additive s) => L f h s -> L g h s -> L (f :*: g) h s
 pattern u :| v <- (unjoin2 -> (u,v)) where (:|) = (:|#)
 {-# complete (:|) #-}
-
--- pattern Join :: V h => h (L f g s) -> L (h :.: f) g s
--- pattern Join ms <- (unjoinL -> ms) where Join = JoinL
--- {-# complete Join #-}
 
 unforkL :: V3 f g h => L f (h :.: g) s -> h (L f g s)
 unforkL (p :|# q)  = liftR2 (:|#) (unforkL p) (unforkL q)
@@ -179,7 +175,7 @@ instance (V f, Semiring s) => Semiring (L f f s) where
 
 -- Binary injections
 
-inl :: (V a, V b, Semiring s) => L a (a :*: b) s 
+inl :: (V2 a b, Semiring s) => L a (a :*: b) s 
 inl = idL :& zero
 
 inr :: (V2 a b, Semiring s) => L b (a :*: b) s 
@@ -237,18 +233,6 @@ pattern RowToL :: (ToScalar a, Additive s) => a s -> L a Par1 s
 pattern RowToL a <- (lToRow -> a) where RowToL = rowToL
 {-# complete RowToL #-}
 
-pattern LToRow :: (ToScalar a, Additive s) => L a Par1 s -> a s
-pattern LToRow m <- (rowToL -> m) where LToRow = lToRow
-{-# complete LToRow :: () #-}
-
--- • A type signature must be provided for a set of polymorphic pattern synonyms.
--- • In {-# complete LToRow #-}
--- |
--- | {-# complete LToRow #-}
-
--- The ":: ()" gets around this error message, but I don't know whether the
--- pattern will still work.
-
 type ToScalar2 a b = (ToScalar a, ToScalar b)
 
 instance ToScalar Par1 where
@@ -284,10 +268,6 @@ type ToRowMajor2 a b = (ToRowMajor a, ToRowMajor b)
 pattern RowMajToL :: (V a, ToRowMajor b, Additive s) => Rows a b s -> L a b s
 pattern RowMajToL as <- (lToRowMaj -> as) where RowMajToL = rowMajToL
 {-# complete RowMajToL #-}
-
-pattern LToRowMaj :: (V a, ToRowMajor b, Additive s) => L a b s -> Rows a b s
-pattern LToRowMaj m <- (rowMajToL -> m) where LToRowMaj = lToRowMaj
-{-# complete LToRowMaj :: () #-} -- see LToRow comment
 
 instance ToRowMajor Par1 where
   rowMajToL (Par1 a) = rowToL a

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -301,6 +301,8 @@ instance V2 a b => ToRowMajor (b :.: a) where
   rowMajToL (Comp1 as) = Fork (rowMajToL <$> as)
   lToRowMaj (Fork m) = Comp1 (lToRowMaj <$> m)
 
+-- TODO: Similarly for ToCol and ToColMajor
+
 -- The zero linear map
 zeroL :: (V2 a b, Additive s) => L a b s
 zeroL = rowMajToL (pureRep (pureRep zero))


### PR DESCRIPTION
This branch removes the `Zero :: L a b s` constructor for `L`. The tricky bit is synthesizing `zero :: L a b s` for all of the `a` and `b` we’ll want, which for now are built up from `Par1`, `(:*:)`, and `(:.:)`. This implementation adds one functor classes to make `L a Par1 s` using join and another for `L a b s` using fork.

Why eliminate `Zero`? To reduce cases considered by each operation, and especially reduce overlap.

We may want to reintroduce `Zero` later as an optimization. If so, we could add some optimizations we didn’t have previously, including binary fork or join of two zeros. I don’t know if n-ary join & fork of zeros is worth detecting.
