### PR TITLE
Add Failable Patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 linalg.cabal
+.stack*

--- a/package.yaml
+++ b/package.yaml
@@ -29,7 +29,7 @@ default-extensions:
   - TypeOperators
   # - UndecidableInstances
   - ViewPatterns
-  # - ScopedTypeVariables
+  - ScopedTypeVariables
   - KindSignatures
   # - NoStarIsType
   - TypeSynonymInstances
@@ -42,6 +42,7 @@ library:
     - base
     - distributive
     - adjunctions
+    - constraints
   other-modules: []
   source-dirs: src
   exposed-modules:

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE UndecidableInstances #-}
 -- | Linear algebra after Fortran
 
 module LinAlg where
@@ -9,6 +10,8 @@ import GHC.Generics (Par1(..), (:*:)(..), (:.:)(..))
 import qualified Control.Arrow as A
 import Data.Distributive
 import Data.Functor.Rep
+import Data.Constraint (Dict(..))
+import Unsafe.Coerce (unsafeCoerce)
 
 infixl 7 :*
 type (:*)  = (,)
@@ -19,7 +22,7 @@ type (:*)  = (,)
 unzip :: Functor f => f (a :* b) -> f a :* f b
 unzip ps = (fst <$> ps, snd <$> ps)
 
-type V f = (Representable f, Foldable f, Eq (Rep f))
+type V f = (Representable f, Foldable f, Eq (Rep f), Traversable f)
 type V2 f g = (V f, V g)
 type V3 f g h = (V2 f g, V h)
 
@@ -50,12 +53,12 @@ infixr 2 :|#
 -- | Compositional Linear map representation. @L f g s@ denotes @f s -* g s@,
 -- where @(-*)@ means linear functions.
 data L :: (* -> *) -> (* -> *) -> (* -> *) where
-  Zero :: L f g s
+  Zero :: V2 f g => L f g s
   Scale :: s -> L Par1 Par1 s
-  (:|#) :: L f h s -> L g h s -> L (f :*: g) h s
-  (:&#) :: L f h s -> L f k s -> L f (h :*: k) s
-  JoinL :: V h => h (L f g s) -> L (h :.: f) g s
-  ForkL :: V h => h (L f g s) -> L f (h :.: g) s
+  (:|#) :: V3 f g h => L f h s -> L g h s -> L (f :*: g) h s
+  (:&#) :: V3 f g h => L f g s -> L f h s -> L f (g :*: h) s
+  JoinL :: V3 f g h => h (L f g s) -> L (h :.: f) g s
+  ForkL :: V3 f g h => h (L f g s) -> L f (h :.: g) s
 
 -- Scalable vectors
 class V a => HasScaleV a where
@@ -71,7 +74,7 @@ instance (HasScaleV a, HasScaleV b) => HasScaleV (a :*: b) where
 instance (HasScaleV a, HasScaleV b, Representable b) => HasScaleV (b :.: a) where
   scaleV s = cross (pureRep (scaleV s))
 
-unjoin2 :: Additive s => L (f :*: g) h s -> L f h s :* L g h s
+unjoin2 :: (Additive s, V3 f g h) => L (f :*: g) h s -> L f h s :* L g h s
 unjoin2 Zero = (zero,zero)
 unjoin2 (p :|# q) = (p,q)
 unjoin2 ((unjoin2 -> (p,q)) :&# (unjoin2 -> (r,s))) = (p :& r, q :& s)
@@ -91,7 +94,7 @@ unjoin2 (ForkL ms) = (ForkL A.*** ForkL) (unzip (unjoin2 <$> ms))
 (ForkL *** ForkL) (unzip (unjoin <$> ms)) :: L f (k :.: h) s :* L g (k :.: h) s
 #endif
 
-unfork2 :: Additive s => L f (h :*: k) s -> L f h s :* L f k s
+unfork2 :: (V3 f g h, Additive s) => L f (g :*: h) s -> L f g s :* L f h s
 unfork2 Zero = (zero,zero)
 unfork2 (p :&# q) = (p,q)
 unfork2 ((unfork2 -> (p,q)) :|# (unfork2 -> (r,s))) = (p :|# r, q :|# s)
@@ -99,11 +102,11 @@ unfork2 (JoinL ms) = (JoinL A.*** JoinL) (unzip (unfork2 <$> ms))
 
 -- unfork2 ((p :& q) :|# (r :& s)) = (p :|# r, q :|# s)
 
-pattern (:&) :: Additive s => L f h s -> L f k s -> L f (h :*: k) s
+pattern (:&) :: (V3 f g h, Additive s) => L f g s -> L f h s -> L f (g :*: h) s
 pattern u :& v <- (unfork2 -> (u,v)) where (:&) = (:&#)
 {-# complete (:&) #-}
 
-pattern (:|) :: Additive s => L f h s -> L g h s -> L (f :*: g) h s
+pattern (:|) :: (V3 f g h, Additive s) => L f h s -> L g h s -> L (f :*: g) h s
 pattern u :| v <- (unjoin2 -> (u,v)) where (:|) = (:|#)
 {-# complete (:|) #-}
 
@@ -111,7 +114,7 @@ pattern u :| v <- (unjoin2 -> (u,v)) where (:|) = (:|#)
 -- pattern Join ms <- (unjoinL -> ms) where Join = JoinL
 -- {-# complete Join #-}
 
-unforkL :: Representable h => L f (h :.: g) s -> h (L f g s)
+unforkL :: (V3 f g h) => L f (h :.: g) s -> h (L f g s)
 unforkL Zero       = pureRep Zero
 unforkL (p :|# q)  = liftR2 (:|#) (unforkL p) (unforkL q)
 unforkL (ForkL ms) = ms
@@ -136,21 +139,21 @@ liftR2 (:|#) (unforkL p) (unforkL p') :: h (L (f :*: f') g s)
 JoinL <$> distrib (unforkL <$> ms) :: h (L (k :.: f) g s)
 #endif
 
-unjoinL :: Representable h => L (h :.: f) g s -> h (L f g s)
+unjoinL :: (V3 f g h) => L (h :.: f) g s -> h (L f g s)
 unjoinL Zero       = pureRep Zero
 unjoinL (p :&# p') = liftR2 (:&#) (unjoinL p) (unjoinL p')
 unjoinL (JoinL ms) = ms
 unjoinL (ForkL ms) = fmap ForkL (distribute (fmap unjoinL ms))
 
-pattern Fork :: V h => h (L f g s) -> L f (h :.: g) s
+pattern Fork :: V3 f g h => h (L f g s) -> L f (h :.: g) s
 pattern Fork ms <- (unforkL -> ms) where Fork = ForkL
 {-# complete Fork #-}
 
-pattern Join :: V h => h (L f g s) -> L (h :.: f) g s
+pattern Join :: V3 f g h => h (L f g s) -> L (h :.: f) g s
 pattern Join ms <- (unjoinL -> ms) where Join = JoinL
 {-# complete Join #-}
 
-instance Additive s => Additive (L f g s) where
+instance (V2 f g, Additive s) => Additive (L f g s) where
   zero = Zero
   Zero + m = m
   m + Zero = m
@@ -176,7 +179,7 @@ idL :: (HasScaleV a, Semiring s) => L a a s
 idL = scaleV one
 
 infixr 9 .@
-(.@) :: Semiring s => L g h s -> L f g s -> L f h s
+(.@) :: (V3 f g h, Semiring s) => L g h s -> L f g s -> L f h s
 Zero      .@ _         = Zero                      -- Zero denotation
 _         .@ Zero      = Zero                      -- linearity
 Scale a   .@ Scale b   = Scale (a * b)             -- Scale denotation
@@ -187,7 +190,7 @@ ForkL ms' .@ m         = ForkL (fmap (.@ m) ms')   -- n-ary product law
 m'        .@ JoinL ms  = JoinL (fmap (m' .@) ms)   -- n-ary coproduct law
 JoinL ms' .@ ForkL ms  = sum (ms' .^ ms)           -- biproduct law
 
-(.^) :: (Representable p, Semiring s) => p (L g h s) -> p (L f g s) -> p (L f h s)
+(.^) :: (Representable p, V3 f g h, Semiring s) => p (L g h s) -> p (L f g s) -> p (L f h s)
 (.^) = liftR2 (.@)
 
 instance (HasScaleV f, Semiring s) => Semiring (L f f s) where
@@ -196,18 +199,18 @@ instance (HasScaleV f, Semiring s) => Semiring (L f f s) where
 
 -- Binary injections
 
-inl :: (HasScaleV a, Semiring s) => L a (a :*: b) s 
+inl :: (HasScaleV a, V b, Semiring s) => L a (a :*: b) s
 inl = idL :& zero
 
-inr :: (HasScaleV b, Semiring s) => L b (a :*: b) s 
+inr :: (HasScaleV b, V a, Semiring s) => L b (a :*: b) s
 inr = zero :& idL
 
 -- Binary projections
 
-exl :: (HasScaleV a, Semiring s) => L (a :*: b) a s 
+exl :: (HasScaleV a, V b, Semiring s) => L (a :*: b) a s
 exl = idL :| zero
 
-exr :: (HasScaleV b, Semiring s) => L (a :*: b) b s 
+exr :: (HasScaleV b, V a, Semiring s) => L (a :*: b) b s
 exr = zero :| idL
 
 -- Note that idL == inl :| inr == exl :& exr.
@@ -223,11 +226,11 @@ exs = unforkL idL
 -- Note that idL == joinL ins == forkL exs
 
 -- Binary biproduct bifunctor
-(***) :: L a c s -> L b d s -> L (a :*: b) (c :*: d) s
+(***) :: (V2 a c, V2 b d) => L a c s -> L b d s -> L (a :*: b) (c :*: d) s
 f *** g = (f :|# Zero) :&# (Zero :|# g)
 
 -- N-ary biproduct bifunctor
-cross :: (V c, Additive s) => c (L a b s) -> L (c :.: a) (c :.: b) s
+cross :: (V3 a b c, Additive s) => c (L a b s) -> L (c :.: a) (c :.: b) s
 cross = JoinL . fmap ForkL . diagRep zero
 
 {- Note that
@@ -241,3 +244,114 @@ cross fs == JoinL (ins .^ fs)
          == ForkL (fs .^ exs)
 
 -}
+
+
+
+ifoldrRep :: forall r a b. (Representable r, Foldable r)
+            => (Rep r -> a -> b -> b) -> b -> r a -> b
+ifoldrRep ix b xs = foldr (uncurry ix) b
+  (tabulate (\(i :: Rep r) -> (i, index xs i)) :: r (Rep r, a))
+
+
+data IsJoin f g s where
+  IsJoin :: V3 f g h => h (L f g s) -> IsJoin (h :.: f) g s
+
+isJoin :: forall f g s. V2 f g => L f g s -> Maybe (IsJoin f g s)
+isJoin Zero       = Nothing -- IsJoin (pureRep Zero)
+isJoin (Scale _)  = Nothing
+isJoin (_ :|# _)  = Nothing
+isJoin (p :&# q) = case (isJoin p, isJoin q) of
+  (Just (IsJoin p'), Just (IsJoin q')) -> Just (IsJoin (liftR2 (:&#) p' q'))
+  _ -> Nothing
+isJoin (JoinL ms) = Just (IsJoin ms)
+isJoin (ForkL (ms :: k (L f g' s))) = case sequenceA (isJoin <$> ms) of
+  Just ys -> case ifoldrRep go (unsafeCoerce $ Dict @(), Nothing, const undefined) ys of
+    (Dict, Just Dict, k) -> Just $ IsJoin $ fmap ForkL $ distribute $ tabulate k
+    _ -> Nothing
+  Nothing -> Nothing
+  where
+    go :: Rep k -> IsJoin f g' s -> (Dict (f ~ (h :.: f')), Maybe (Dict (V2 f' h)), Rep k -> h (L f' g' s))
+       -> (Dict (f ~ (h :.: f')), Maybe (Dict (V2 f' h)), Rep k -> h (L f' g' s))
+    go k (IsJoin hs) (Dict, _, fun) = (Dict, Just Dict, \k' -> if k == k' then hs else fun k')
+
+pattern Join' :: (V2 f g) => (f ~ (h :.: f'), V2 h f') => h (L f' g s) -> L f g s
+pattern Join' ms <- (isJoin -> Just (IsJoin ms)) where Join' = JoinL
+
+
+data IsFork f g s where
+  IsFork :: V3 f g h => h (L f g s) -> IsFork f (h :.: g) s
+
+isFork :: V2 f g => L f g s -> Maybe (IsFork f g s)
+isFork Zero       = Nothing --IsJoin (pureRep Zero)
+isFork (Scale _)  = Nothing
+isFork (_ :&# _)  = Nothing
+isFork (p :|# q) = case (isFork p, isFork q) of
+  (Just (IsFork p'), Just (IsFork q')) -> Just $ IsFork (liftR2 (:|#) p' q')
+  _ -> Nothing
+isFork (ForkL ms) = Just $ IsFork ms
+isFork (JoinL (ms :: k (L f' g s))) = case sequenceA (isFork <$> ms) of
+  Just ys -> case ifoldrRep go (unsafeCoerce $ Dict @(), Nothing, const undefined) ys of
+    (Dict, Just Dict, k) -> Just $ IsFork $ fmap JoinL $ distribute $ tabulate k
+    _ -> Nothing
+  Nothing -> Nothing
+  where
+    go :: Rep k -> IsFork f' g s -> (Dict (g ~ (h :.: g')), Maybe (Dict (V2 g' h)), Rep k -> h (L f' g' s))
+       -> (Dict (g ~ (h :.: g')), Maybe (Dict (V2 g' h)), Rep k -> h (L f' g' s))
+    go k (IsFork hs) (Dict, _, fun) = (Dict, Just Dict, \k' -> if k == k' then hs else fun k')
+
+pattern Fork' :: (V2 f g) => (g ~ (h :.: g'), V2 h g') => h (L f g' s) -> L f g s
+pattern Fork' ms <- (isFork -> Just (IsFork ms)) where Fork' = ForkL
+
+
+
+data IsJoin2 f g s where
+  IsJoin2 :: V3 f g h => L f h s -> L g h s -> IsJoin2 (f :*: g) h s
+
+isJoin2 :: forall f g s. V2 f g => L f g s -> Maybe (IsJoin2 f g s)
+isJoin2 Zero       = Nothing -- IsJoin2 (pureRep Zero)
+isJoin2 (Scale _)  = Nothing
+isJoin2 (p :|# q)  = Just $ IsJoin2 p q
+isJoin2 (p :&# q) = case (isJoin2 p, isJoin2 q) of
+  (Just (IsJoin2 p' p''), Just (IsJoin2 q' q'')) -> Just $ IsJoin2 (p' :&# q') (p'' :&# q'')
+  _ -> Nothing
+isJoin2 (JoinL _) = Nothing
+isJoin2 (ForkL (ms :: k (L f g' s))) = case sequenceA (isJoin2 <$> ms) of
+  Just ys -> case ifoldrRep go (unsafeCoerce $ Dict @(), Nothing, const undefined) ys of
+    (Dict, Just Dict, k) -> Just $ uncurry IsJoin2 $ ForkL A.*** ForkL $ unzip $ tabulate k
+    _ -> Nothing
+  Nothing -> Nothing
+  where
+    go :: Rep k -> IsJoin2 f g' s -> (Dict (f ~ (f' :*: h)), Maybe (Dict (V2 f' h)), Rep k -> (L f' g' s, L h g' s))
+       -> (Dict (f ~ (f' :*: h)), Maybe (Dict (V2 f' h)), Rep k -> (L f' g' s, L h g' s))
+    go k (IsJoin2 f g) (Dict, _, fun) = (Dict, Just Dict, \k' -> if k == k' then (f,g) else fun k')
+
+pattern (:|:) :: (V2 f g) => (f ~ (f' :*: h), V2 f' h) => L f' g s -> L h g s -> L f g s
+pattern f :|: g <- (isJoin2 -> Just (IsJoin2 f g)) where (:|:) = (:|#)
+
+
+
+data IsFork2 f g s where
+  IsFork2 :: V3 f g h => L f g s -> L f h s -> IsFork2 f (g :*: h) s
+
+isFork2 :: forall f g s. V2 f g => L f g s -> Maybe (IsFork2 f g s)
+isFork2 Zero       = Nothing -- IsFork2 (pureRep Zero)
+isFork2 (Scale _)  = Nothing
+isFork2 (p :&# q)  = Just $ IsFork2 p q
+isFork2 (p :|# q) = case (isFork2 p, isFork2 q) of
+  (Just (IsFork2 p' p''), Just (IsFork2 q' q'')) -> Just $ IsFork2 (p' :|# q') (p'' :|# q'')
+  _ -> Nothing
+isFork2 (ForkL _) = Nothing
+isFork2 (JoinL (ms :: k (L f' g s))) = case sequenceA (isFork2 <$> ms) of
+  Just ys -> case ifoldrRep go (unsafeCoerce $ Dict @(), Nothing, const undefined) ys of
+    (Dict, Just Dict, k) -> Just $ uncurry IsFork2 $ JoinL A.*** JoinL $ unzip $ tabulate k
+    _ -> Nothing
+  Nothing -> Nothing
+  where
+    go :: Rep k -> IsFork2 f' g s -> (Dict (g ~ (g' :*: h)), Maybe (Dict (V2 g' h)), Rep k -> (L f' g' s, L f' h s))
+       -> (Dict (g ~ (g' :*: h)), Maybe (Dict (V2 g' h)), Rep k -> (L f' g' s, L f' h s))
+    go k (IsFork2 f g) (Dict, _, fun) = (Dict, Just Dict, \k' -> if k == k' then (f,g) else fun k')
+
+pattern (:&:) :: (V2 f g) => (g ~ (g' :*: h), V2 g' h) => L f g' s -> L f h s -> L f g s
+pattern f :&: g <- (isFork2 -> Just (IsFork2 f g)) where (:&:) = (:&#)
+
+-- {-# COMPLETE Zero, Scale, (:&:), (:|:), Join', Fork' #-}


### PR DESCRIPTION
These don't work exactly how I expected them to, but I'm opening the PR anyway for discussion.

## Overview

This PR adds four "failable" patterns for the four interesting constructors of `L`.  In order to not have any naming conflicts, I named them  `(:|:)`, `(:&:)`, `Join'`, and `Fork'`.

A failable pattern is one that _may_ not match.  For instance, a value of type `L f g s` _might_ indeed be an n-ary join, but since we don't know what `f` is, we don't know for sure.  Using the `Join'` pattern is much like using the `JoinL` pattern in that it may not match, but if it does, then we are guaranteed that there exists some `h` and `f'` such that `f ~ (h :.: f')`.  Because of this, we can use the `Fork'` pattern in more places than we can use the `Fork` pattern and not get annoying type errors.

One repercussion of failable patterns is that no individual pattern is "complete".  Rather, we can only guarantee a match if we try all 4 new patterns together (along with `Scale` and `Zero`).  This is actually quite sensible and not a particular downside.

In short, these failable patterns are the ideal for what we want when pattern-matching a value of type `L f g s`.  They're more general than the constructors (`Fork'` may match even if `ForkL` doesn't) but not type-restricted like the current patterns.

## Downsides

There are 4 major downsides of these failable patterns.  Any one of them might be a showstopper, and I'm not sure they're all fixable.

### Zero

Because the failable patterns are not type-restricted like the current pattern synonyms are, they must instead be type-_directed_.  That is, matching or failing to match must be determined by the types, and the constraint that the pattern produces (like `f ~ (h :.: f')` in my above example for `Join'`) must be directed from the types.  This is fine for a normal join or fork — using the GADT constructors _is_ type-directed, and matching on, say, `JoinL` yields the types `h` and `f'` that we need — but it is impossible for `Zero`.  In short, I'm not sure it's possible to support these failable patterns while `Zero` is a constructor and still have them do the "right thing".

There are two solutions.  One is remove the `Zero` constructor.  This may be bad for performance/optimizations, but it eases reasoning now.  The other is to declare that `Zero` cannot be matched by any of these new failable patterns.  In practice, this is not a problem (just match against `Zero` first any time you're doing pattern matching), but the theory is not so nice.


### Ugly Implementation

This is the implementation I came up with for the pattern `Join'` when the constructor is a `ForkL`
```haskell
isJoin :: forall f g s. V2 f g => L f g s -> Maybe (IsJoin f g s)
isJoin (ForkL (ms :: k (L f g' s))) = case sequenceA (isJoin <$> ms) of
  Just ys -> case ifoldrRep go (unsafeCoerce $ Dict @(), Nothing, const undefined) ys of
    (Dict, Just Dict, k) -> Just $ IsJoin $ fmap ForkL $ distribute $ tabulate k
    _ -> Nothing
  Nothing -> Nothing
  where
    go :: Rep k -> IsJoin f g' s -> (Dict (f ~ (h :.: f')), Maybe (Dict (V2 f' h)), Rep k -> h (L f' g' s))
       -> (Dict (f ~ (h :.: f')), Maybe (Dict (V2 f' h)), Rep k -> h (L f' g' s))
    go k (IsJoin hs) (Dict, _, fun) = (Dict, Just Dict, \k' -> if k == k' then hs else fun k')
```
Ooof!  Not only did I have to add `Traversable` to `V`, implement a new `ifoldrRep` function, and bring in `Dict` from the `constraints` package, but I _still_ end up using `unsafeCoerce` and `undefined`.  All that said, I'm quite confident it does the right thing.  For instance, the `undefined` should be impossible to access, and the `unsafeCoerce` ends up being guarded.  (Also, I think the `undefined` could be replaced by a clever use of `fix`.)

### Bad Type-Checker Performance

I have no idea why, but when I add the line
```haskell
{-# COMPLETE Zero, Scale, (:&:), (:|:), Join', Fork' #-}
```
to the module, type checking slows to a crawl.  In fact, I thought I may have put it into an infinite loop, but after waiting long enough, it really did finish.  I wonder if others can reproduce this.

### Insufficient Complete Pragmas

The new patterns are a little frustrating because while they're ideal for matching against an arbitrary value of type `L f g s`, they suffer from the same drawbacks as the regular constructors when matching against values with more constrained types.  For instance, we know that a value of type `L (h :.: f) g s` will always successfully match to the pattern `Join' ms`, but as far as I can tell, there's no way to tell GHC this fact.  This is pretty frustrating as it means that a double pattern match will yield "non-exhaustive pattern match" errors even when we know the match is exhaustive.  For instance, consider a case in the definition of `(+)`:
```haskell
  Join' ms  + Join' ms' = Join' (ms +^ ms')
```
If the first argument matches, we know that the second argument will also match, but GHC does not.  It will instead argue that we should provide two more cases, of the forms
```haskell
  (Join' _) + (Fork' _)
  (Join' _) + (_ :&: _)
```
"just in case" the second argument turned out not to match `Join'`.

The easy way to fix this is to use type-restricted patterns on the right-hand side, but this means we need to keep around all of our type-restricted patterns.  The question then becomes, what have these failable patterns actually given us?

## Failable Patterns in Practice

The main benefit of failable patterns is that if a value is inherently, say, a fork, then it will always succeed when matching against `Fork'`.  This is a great power, but it does seem a little weird too.  Consider the following operation:
```haskell
foo :: L f g s -> String
foo (ForkL _) = "Fork"
foo (JoinL _) = "Join"
foo _         = "Other"
```
Also consider a value `v :: L (c :.: a) (c :.: b) s` for some `a`, `b`, and `c`.  What should `foo v` be?  Well, it will depend on exactly how `foo` was constructed.  This means that `foo` is _data-directed_.  Now consider these two alternatives:
```haskell
fooF :: L f g s -> String
fooF (Fork' _) = "Fork"
fooF (Join' _) = "Join"
fooF _         = "Other"

fooJ :: L f g s -> String
fooJ (Join' _) = "Join"
fooJ (Fork' _) = "Fork"
fooJ _         = "Other"
```
Regardless of how we constructed `v`, `fooF v` will always be `"Fork"` and `fooJ v` will always be `"Join"`.  Our functions are no longer data driven, and indeed, the order of the lines of the definition has a very real impact on the result of the function.  Even for functions that preserve semantic behavior in all match orderings, there may be performance effects.

I'm not saying this is inherently a bad or good thing, but it is definitely notable.
