### PR TITLE
Specification

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,11 +21,12 @@ default-extensions:
   - FunctionalDependencies
   - GADTs
   # - GeneralizedNewtypeDeriving
+  - InstanceSigs
   # - LambdaCase
   - MultiParamTypeClasses
   - PatternSynonyms
   # - QuantifiedConstraints
-  # - RankNTypes
+  - RankNTypes
   # - StandaloneDeriving
   # - TupleSections
   - TypeApplications

--- a/package.yaml
+++ b/package.yaml
@@ -45,6 +45,7 @@ library:
   dependencies:
     - base
     - ghc-prim  # GHC.Types (Constraint)
+    - constraints  # Experiment
     - distributive
     - adjunctions
   other-modules: []

--- a/package.yaml
+++ b/package.yaml
@@ -17,15 +17,14 @@ default-extensions:
   - GADTs
   # - GeneralizedNewtypeDeriving
   # - LambdaCase
-  # - MultiParamTypeClasses
-  # - OverloadedStrings  # for Poly, since dante doesn't pick up
+  - MultiParamTypeClasses
   - PatternSynonyms
   # - QuantifiedConstraints
   # - RankNTypes
   # - StandaloneDeriving
   # - TupleSections
   - TypeApplications
-  # - TypeFamilies
+  - TypeFamilies
   - TypeOperators
   # - UndecidableInstances
   - ViewPatterns
@@ -33,6 +32,7 @@ default-extensions:
   - KindSignatures
   # - NoStarIsType
   - TypeSynonymInstances
+  - PolyKinds
 
 ghc-options:
   -Wall
@@ -40,9 +40,13 @@ ghc-options:
 library:
   dependencies:
     - base
+    - ghc-prim  # GHC.Types (Constraint)
     - distributive
     - adjunctions
   other-modules: []
   source-dirs: src
   exposed-modules:
+    - Misc
     - LinAlg
+    - Category
+    - F

--- a/package.yaml
+++ b/package.yaml
@@ -6,7 +6,7 @@ description:         Please see the README on GitHub at <https://github.com/cona
 
 # Common language extensions defining the default language for the project.
 # Un-comment each extension the first time it's used in a module.
-# UndecidableInstances and AllowAmbiguousTypes instead go in the modules with
+# Undecidable* and AllowAmbiguousTypes instead go in the modules with
 # a corresponding GHC error comment right after the code that generates the
 # warning. See LinAlg for an example.
 
@@ -25,7 +25,7 @@ default-extensions:
   # - LambdaCase
   - MultiParamTypeClasses
   - PatternSynonyms
-  # - QuantifiedConstraints
+  - QuantifiedConstraints
   - RankNTypes
   # - StandaloneDeriving
   # - TupleSections
@@ -52,6 +52,7 @@ library:
   source-dirs: src
   exposed-modules:
     - Misc
-    - LinAlg
     - Category
     - F
+    - InductiveMatrix # coming
+    - LinAlg          # going

--- a/package.yaml
+++ b/package.yaml
@@ -53,6 +53,6 @@ library:
   exposed-modules:
     - Misc
     - Category
-    - F
+    - LinearFunction
     - InductiveMatrix # coming
     - LinAlg          # going

--- a/package.yaml
+++ b/package.yaml
@@ -13,7 +13,7 @@ default-extensions:
   # - DeriveFunctor
   - FlexibleContexts
   - FlexibleInstances
-  # - FunctionalDependencies
+  - FunctionalDependencies
   - GADTs
   # - GeneralizedNewtypeDeriving
   # - LambdaCase

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -190,5 +190,4 @@ unjoin f = (f .) <$> ins
 
 class (Biproduct (l s) p, BiproductR (l s)) => Linear s l p where
   scale :: s -> l s Par1 Par1
-  infixl 9 @@  -- Linear application
-  (@@) :: l s a b -> a s -> b s  -- linear
+  at :: l s a b -> a s -> b s  -- linear

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -70,9 +70,9 @@ class (Category k, ObjBin k p) => Monoidal k p | k -> p where
 -- definitions look in comparison.
 --
 -- @dwincort (https://github.com/conal/linalg/pull/28#discussion_r466989563):
--- From what I can tell, if we use `QuantifiedConstraints` with `p`, then we
+-- "From what I can tell, if we use `QuantifiedConstraints` with `p`, then we
 -- can't turn it into an associated type. I'm not sure that's so bad, but it's
--- worth noting.
+-- worth noting." See also the GHC error message there.
 --
 -- TODO: keep poking at this question.
 
@@ -101,7 +101,7 @@ unfork2 :: (Cartesian k p, Obj3 k a c d)
         => (a `k` (c `p` d)) -> ((a `k` c) :* (a `k` d))
 unfork2 f = (exl . f , exr . f)
 
--- TODO: How can we know that uncurry (&&&) and unfork2 form an isomorphism?
+-- Exercise: Prove that uncurry (&&&) and unfork2 form an isomorphism.
 
 pattern (:&) :: (Cartesian k p, Obj3 k a c d)
              => (a `k` c) -> (a `k` d) -> (a `k` (c `p` d))
@@ -138,7 +138,7 @@ unjoin2 :: (Cocartesian k co, Obj3 k a b c)
         => ((a `co` b) `k` c) -> ((a `k` c) :* (b `k` c))
 unjoin2 f = (f . inl , f . inr)
 
--- TODO: How can we know that uncurry (|||) and unjoin2 form an isomorphism?
+-- Exercise: Prove that uncurry (|||) and unjoin2 form an isomorphism.
 
 pattern (:|) :: (Cocartesian k co, Obj3 k a b c)
              => (a `k` c) -> (b `k` c) -> ((a `co` b) `k` c)
@@ -191,7 +191,7 @@ unfork :: (CartesianR k, Obj2 k a b, ObjR k r)
        => a `k` (r :.: b) -> r (a `k` b)
 unfork f = (. f) <$> exs
 
--- TODO: How can we know that fork and unfork form an isomorphism?
+-- Exercise: Prove that fork and unfork form an isomorphism.
 
 -- N-ary biproducts
 class CartesianR k => BiproductR k where

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE UndecidableInstances #-} -- see below
 {-# LANGUAGE UndecidableSuperClasses #-} -- see below
 

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -1,0 +1,110 @@
+-- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
+
+-- | Functor category classes
+
+module Category where
+
+import qualified Prelude as P
+import Prelude hiding (id,(.))
+import GHC.Types (Constraint)
+import qualified Control.Arrow as A
+-- import qualified Data.Tuple as T
+import Data.Functor.Rep
+
+import Misc
+
+class    Yes1 a
+instance Yes1 a
+
+class Category (k :: u -> u -> *) where
+  type Obj k :: u -> Constraint
+  infixr 9 .
+  id :: Obj k a => a `k` a
+  (.) :: (b `k` c) -> (a `k` b) -> (a `k` c)
+
+-- Experiment: omit Obj constraints for argument arrows.
+
+type Obj2 k a b         = C2 (Obj k) a b
+type Obj3 k a b c       = C3 (Obj k) a b c
+type Obj4 k a b c d     = C4 (Obj k) a b c d
+type Obj5 k a b c d e   = C5 (Obj k) a b c d e
+type Obj6 k a b c d e f = C6 (Obj k) a b c d e f
+
+class Category k => Monoidal k p where
+  infixr 3 ***
+  (***) :: (a `k` c) -> (b `k` d) -> ((a `p` b) `k` (c `p` d))
+
+-- Should we require p to be uniquely determined by k? Might help type
+-- inference. We'd then need a "Comonoidal" class with "(+++)", which is
+-- perhaps better.
+
+class Monoidal k p => Cartesian k p where
+  exl :: Obj2 k a b => (a `p` b) `k` a
+  exr :: Obj2 k a b => (a `p` b) `k` b
+  dup :: Obj  k a   => a `k` (a `p` a)
+
+infixr 3 &&&
+(&&&) :: (Cartesian k p, Obj3 k a c d)
+      => (a `k` c) -> (a `k` d) -> (a `k` (c `p` d))
+f &&& g = (f *** g) . dup
+
+-- Can I instead extract the Obj constraints from f and g?
+
+class Monoidal k c => Cocartesian k c where
+  inl :: Obj2 k a b => a `k` (a `c` b)
+  inr :: Obj2 k a b => b `k` (a `c` b)
+  jam :: Obj  k a   => (a `c` a) `k` a
+
+-- N-ary (representable) counterparts
+
+class Representable p => MonoidalRep k p where
+  exs :: p (p a `k` a)
+  dups :: a `k` p a
+
+-- TODO: keep Representable p superclass constraint?
+
+-- Oops! The type p (p a `k` a) requires p :: * -> *, hence p a :: *, a :: *.
+-- The Representable constraint does as well.
+--
+--   λ> :k Monoidal
+--   Monoidal :: (u -> u -> *) -> (u -> u -> u) -> Constraint
+--   λ> :k MonoidalRep
+--   MonoidalRep :: (* -> * -> *) -> (* -> *) -> Constraint
+--
+-- For L, we have
+-- 
+--   exs :: (...) => c (L (c :.: a) a s)
+--
+-- What's generalization are we after here?
+
+
+-- Instances
+
+instance Category (->) where
+  type Obj (->) = Yes1
+  id = P.id
+  (.) = (P..)
+
+instance Monoidal (->) (:*) where
+  (***) = (A.***)
+
+instance Cartesian (->) (:*) where
+  exl = fst
+  exr = snd
+  dup = \ a -> (a,a)
+
+instance Monoidal (->) (:+) where
+  (***) = (A.+++)
+
+-- Should we instead define a Comonoidal class with (+++)?
+
+instance Cocartesian (->) (:+) where
+  inl = P.Left
+  inr = P.Right
+  jam = id A.||| id
+  -- jam (Left  a) = a
+  -- jam (Right a) = a
+
+instance Representable p => MonoidalRep (->) p where
+  exs = tabulate (flip index)
+  dups = pureRep

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -103,6 +103,10 @@ unfork2 f = (exl . f , exr . f)
 
 -- Exercise: Prove that uncurry (&&&) and unfork2 form an isomorphism.
 
+-- TODO: Add (&&&) and unfork2 to Cartesian with the current definitions as
+-- defaults, and give defaults for exl, exr, and dup in terms of (&&&) and
+-- unfork2. Use MINIMAL pragmas.
+
 pattern (:&) :: (Cartesian k p, Obj3 k a c d)
              => (a `k` c) -> (a `k` d) -> (a `k` (c `p` d))
 pattern f :& g <- (unfork2 -> (f,g)) where (:&) = (&&&)
@@ -139,6 +143,10 @@ unjoin2 :: (Cocartesian k co, Obj3 k a b c)
 unjoin2 f = (f . inl , f . inr)
 
 -- Exercise: Prove that uncurry (|||) and unjoin2 form an isomorphism.
+
+-- TODO: Add (|||) and unjoin2 to Cartesian with the current definitions as
+-- defaults, and give defaults for exl, exr, and dup in terms of (|||) and
+-- unjoin2. Use MINIMAL pragmas.
 
 pattern (:|) :: (Cocartesian k co, Obj3 k a b c)
              => (a `k` c) -> (b `k` c) -> ((a `co` b) `k` c)
@@ -210,7 +218,7 @@ unjoin :: (BiproductR k, Obj2 k a b, ObjR k r, Eq (Rep r))
 unjoin f = (f .) <$> ins
 
 -- TODO: Add fork & unfork to CartesianR with the current definitions as
--- defaults and giving defaults for exs and dups in terms of fork and unfork.
+-- defaults, and give defaults for exs and dups in terms of fork and unfork.
 -- Ditto for ins/jams and join/unjoin. Use MINIMAL pragmas.
 
 -- Add Abelian?

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -98,7 +98,8 @@ infixr 2 |||
 f ||| g = jam . (f +++ g)
 
 -- Inverse of uncurry (|||)
-unjoin2 :: (Cocartesian k co, Obj2 k a b) => ((a `co` b) `k` c) -> ((a `k` c) :* (b `k` c))
+unjoin2 :: (Cocartesian k co, Obj2 k a b)
+        => ((a `co` b) `k` c) -> ((a `k` c) :* (b `k` c))
 unjoin2 f = (f . inl , f . inr)
 
 -- TODO: How can we know that uncurry (|||) and unjoin2 form an isomorphism?
@@ -156,7 +157,8 @@ class MonoidalR k => CartesianR k where
   exs :: Representable r => r ((r :.: a) `k` a)
   dups :: Representable r => a `k` (r :.: a)
 
-fork :: (CartesianR k, Obj2 k a c, Representable r) => r (a `k` c) -> (a `k` (r :.: c))
+fork :: (CartesianR k, Obj2 k a c, Representable r)
+     => r (a `k` c) -> (a `k` (r :.: c))
 fork fs = cross fs . dups
 
 unfork :: (CartesianR k, Representable r) => a `k` (r :.: b) -> r (a `k` b)
@@ -172,7 +174,8 @@ class CartesianR k => BiproductR k where
 -- TODO: Maybe replace (Representable r, Eq (Rep r), Foldable r) with an
 -- associated functor constraint.
 
-join :: (BiproductR k, Representable r, Foldable r, Obj2 k a b) => r (a `k` b) -> (r :.: a) `k` b
+join :: (BiproductR k, Representable r, Foldable r, Obj2 k a b)
+     => r (a `k` b) -> (r :.: a) `k` b
 join fs = jams . cross fs  -- note cross == plus
 
 unjoin :: (BiproductR k, Obj2 k a b, Representable r, Eq (Rep r))

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -254,18 +254,18 @@ instance Category (:-) where
 class    (p,q) => p && q
 instance (p,q) => p && q
 
--- Data.Constraints exports equivalents of Monoidal and Cartesian operations,
--- but their types involve (,) instead of (&&), leading to kind errors.
-
 instance Monoidal (:-) (&&) where
-  p *** q = Sub $ Dict \\ p \\ q
+  p *** q = Sub (Dict \\ p \\ q)
 
 instance Cartesian (:-) (&&) where
   exl = Sub Dict
   exr = Sub Dict
   dup = Sub Dict
 
--- Constraint entailment can be cocartesian, but it isn't in GHC (presumably
--- because GHC doesn't do backtracing instance search). On the other hand,
--- entaliment can probably be closed, now that GHC supports implication
--- constraints.
+-- The Monoidal and Cartesian operations are lifted from Data.Constraint
+-- equivalents but those types involve (,) instead of (&&), which would lead to
+-- kind errors in instance declarations.
+
+-- Constraint entailment could be cocartesian but isn't in GHC (presumably
+-- because GHC instance search doesn't backtrac). On the other hand, entaliment
+-- can probably be closed, now that GHC supports implication constraints.

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -188,6 +188,5 @@ unjoin f = (f .) <$> ins
 
 -- TODO: Abelian
 
-class (Biproduct (l s) p, BiproductR (l s)) => Linear s l p where
+class (Biproduct (l s) p, BiproductR (l s)) => Scalable s l p where
   scale :: s -> l s Par1 Par1
-  at :: l s a b -> a s -> b s  -- linear

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -108,8 +108,9 @@ class (Representable r, ComonoidalR k r) => CocartesianR k r where
   ins :: r (a `k` (Rep r :* a))
   jams :: (Rep r :* a) `k` a
 
--- Conal: I think (Repr r :*) is the right choice for n-ary sums.
--- See how it works out.
+-- Conal: Is Repr r :* the right choice for n-ary coproducts? See how it works
+-- out. No. For linear maps (and thus for their representations), we'll want r a
+-- instead, with jams = sum and one-hot ins.
 
 -- Couldn't match type ‘Rep r0’ with ‘Rep r’
 -- Expected type: k (Rep r :* a) a

--- a/src/F.hs
+++ b/src/F.hs
@@ -8,7 +8,7 @@ module F where
 
 import Prelude hiding (id,(.),(+),(*),sum)
 
-import GHC.Generics ((:*:)(..),(:.:)(..))
+import GHC.Generics (Par1(..),(:*:)(..),(:.:)(..))
 import Data.Functor.Rep
 
 import Misc
@@ -18,7 +18,7 @@ import Category
 newtype F (s :: *) a b = F { unF :: a s -> b s }
 
 instance Category (F s) where
-  type Obj (F s) = Representable 
+  type Obj' (F s) = Representable 
   id = F id
   F g . F f = F (g . f)
 
@@ -74,6 +74,9 @@ instance Additive s => BiproductR (F s) where
 oneHot :: (C2 Representable r a, Eq (Rep r), Additive s)
        => Rep r -> a s -> (r :.: a) s
 oneHot i a = Comp1 (tabulate (\ j -> if i == j then a else zeroV))
+
+class (Biproduct (l s) p, BiproductR (l s)) => Scalable s l p where
+  scale :: s -> l s Par1 Par1
 
 instance Semiring s => Scalable s F (:*:) where
   scale s = F (fmap (s *))   -- F (\ (Par1 s') -> Par1 (s * s'))

--- a/src/F.hs
+++ b/src/F.hs
@@ -1,36 +1,86 @@
+{-# LANGUAGE UndecidableInstances #-}  -- See below
 -- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
 
--- | Linear functions, providing denotational specification for L.
+-- | Linear functions, providing denotational specification for all linear map
+-- representations.
 
 module F where
 
-import Prelude hiding (id,(.))
+import Prelude hiding (id,(.),sum)
 
-import GHC.Generics ((:*:)(..))
+import GHC.Generics ((:*:)(..),(:.:)(..))
 import Data.Functor.Rep
 
 import Misc
 import Category
 
 -- | Linear functions
-newtype F (s :: *) a b = F (a s -> b s)
+newtype F (s :: *) a b = F { unF :: a s -> b s }
 
 instance Category (F s) where
   type Obj (F s) = Representable 
   id = F id
   F g . F f = F (g . f)
 
+infixl 9 @@
+(@@) :: F s a b -> (a s -> b s)
+F f @@ a = f a
+
 instance Monoidal (F s) (:*:) where
   F f *** F g = F (\ (a :*: b) -> f a :*: g b)
 
 instance Cartesian (F s) (:*:) where
-  exl = F (\ (a :*: _) -> a)
-  exr = F (\ (_ :*: b) -> b)
-  dup = F (\ a -> a :*: a)
+  exl = F exlF
+  exr = F exrF
+  dup = F dupF
 
 instance Comonoidal (F s) (:*:) where (+++) = (***)
 
 instance Additive s => Cocartesian (F s) (:*:) where
-  inl = F (\ a -> a :*: zeroV)
-  inr = F (\ b -> zeroV :*: b)
-  jam = F (\ (a :*: b) -> a +^ b)
+  inl = F (:*: zeroV)
+  inr = F (zeroV :*:)
+  jam = F (uncurryF (+^))
+
+instance Additive s => Biproduct (F s) (:*:)
+
+-- class (Category k, Representable r) => MonoidalR k r where
+--   cross :: r (a `k` b) -> ((r :.: a) `k` (r :.: b))
+
+instance Representable r => MonoidalR (F s) r where
+  cross :: r (F s a b) -> (F s (r :.: a) (r :.: b))
+  cross fs = F (Comp1 . liftR2 (@@) fs . unComp1)
+
+#if 0
+                    fs :: r (F s a b)
+        liftR2 (@@) fs :: r (a s) -> r (b s)
+Comp1 . liftR2 (@@) fs . unComp1 :: (r :.: a) s -> (r :.: b) s
+#endif
+
+instance Representable r => CartesianR (F s) r where
+  exs :: r (F s (r :.: a) a)
+  exs = tabulate (\ i -> F (\ (Comp1 as) -> as `index` i))
+  dups :: F s a (r :.: a)
+  dups = F (\ a -> Comp1 (pureRep a))
+         -- F (Comp1 . pureRep)
+
+instance (Representable r, Foldable r, Eq (Rep r), Additive s)
+      => BiproductR (F s) r where
+  ins :: Representable a => r (F s a (r :.: a))
+  ins = tabulate (F . oneHot)
+        -- tabulate $ \ i -> F (oneHot i)
+        -- tabulate $ \ i -> F (\ a -> oneHot i a)
+  jams :: Representable a => F s (r :.: a) a
+  jams = F (\ (Comp1 as) -> foldr (+^) zeroV as)
+
+-- TODO: can we define ins without Eq (Rep r)?
+
+-- Illegal nested constraint ‘Eq (Rep r)’
+-- (Use UndecidableInstances to permit this)
+
+oneHot :: (C2 Representable r a, Eq (Rep r), Additive s) => Rep r -> a s -> (r :.: a) s
+oneHot i a = Comp1 (tabulate (\ j -> if i == j then a else zeroV))
+
+-- Circular with ins
+unjoin' :: (C2 Representable r a, Foldable r, Eq (Rep r), Additive s)
+        => F s (r :.: a) c -> r (F s a c)
+unjoin' f = (f .) <$> ins

--- a/src/F.hs
+++ b/src/F.hs
@@ -28,6 +28,8 @@ instance Cartesian (F s) (:*:) where
   exr = F (\ (_ :*: b) -> b)
   dup = F (\ a -> a :*: a)
 
+instance Comonoidal (F s) (:*:) where (+++) = (***)
+
 instance Additive s => Cocartesian (F s) (:*:) where
   inl = F (\ a -> a :*: zeros)
   inr = F (\ b -> zeros :*: b)

--- a/src/F.hs
+++ b/src/F.hs
@@ -81,4 +81,4 @@ oneHot i a = Comp1 (tabulate (\ j -> if i == j then a else zeroV))
 instance Semiring s => Linear s F (:*:) where
   scale s = F (fmap (s *))
             -- F (\ (Par1 s') -> Par1 (s * s'))
-  F f @@ a = f a
+  (@@) = unF

--- a/src/F.hs
+++ b/src/F.hs
@@ -39,7 +39,7 @@ instance Additive s => Cocartesian (F s) (:*:) where
 
 instance Additive s => Biproduct (F s) (:*:)
 
-instance Additive s => MonoidalR (F s) where
+instance MonoidalR (F s) where
   cross :: Representable r => r (F s a b) -> F s (r :.: a) (r :.: b)
   cross fs = F (Comp1 . liftR2 unF fs . unComp1)
 
@@ -51,7 +51,7 @@ Comp1 . liftR2 unF fs . unComp1 :: (r :.: a) s -> (r :.: b) s
 cross = F . inNew (liftR2 unF)
 #endif
 
-instance Additive s => CartesianR (F s) where
+instance CartesianR (F s) where
   exs :: Representable r => r (F s (r :.: a) a)
   exs = tabulate (\ i -> F (\ (Comp1 as) -> as `index` i))
   dups :: Representable r => F s a (r :.: a)
@@ -75,13 +75,13 @@ oneHot :: (C2 Representable r a, Eq (Rep r), Additive s)
        => Rep r -> a s -> (r :.: a) s
 oneHot i a = Comp1 (tabulate (\ j -> if i == j then a else zeroV))
 
-class (Biproduct (l s) p, BiproductR (l s)) => Scalable s l p where
-  scale :: s -> l s Par1 Par1
+class Scalable l where
+  scale :: Semiring s => s -> l s Par1 Par1
 
-instance Semiring s => Scalable s F (:*:) where
+instance Scalable F where
   scale s = F (fmap (s *))   -- F (\ (Par1 s') -> Par1 (s * s'))
 
-class Linear l where
+class LinearMap l where
   -- | Semantic function for all linear map representations. Correctness of
   -- every operation on every representation is specified by requiring that mu
   -- is homomorphic for (distributes over) that operation. For instance, mu must
@@ -91,6 +91,6 @@ class Linear l where
   mu' :: F s a b -> l s a b
 
 -- Trivial instance
-instance Linear F where
+instance LinearMap F where
   mu  = id
   mu' = id

--- a/src/F.hs
+++ b/src/F.hs
@@ -1,8 +1,6 @@
 -- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
 
--- | Linear functions
---
--- 
+-- | Linear functions, providing denotational specification for L.
 
 module F where
 

--- a/src/F.hs
+++ b/src/F.hs
@@ -31,25 +31,6 @@ instance Cartesian (F s) (:*:) where
 instance Comonoidal (F s) (:*:) where (+++) = (***)
 
 instance Additive s => Cocartesian (F s) (:*:) where
-  inl = F (\ a -> a :*: zeros)
-  inr = F (\ b -> zeros :*: b)
+  inl = F (\ a -> a :*: zeroV)
+  inr = F (\ b -> zeroV :*: b)
   jam = F (\ (a :*: b) -> a +^ b)
-
-#if 0
-
-instance Representable p => MonoidalRep (F s) p where
-  -- exs = tabulate (\ i -> F (\ a -> a `index` i))
-  --     = tabulate (\ i -> F (`index` i))
-  --     = tabulate (\ i -> F (flip index i))
-  --     = tabulate (F . flip index)
-
--- Error:
--- 
---   Expected kind ‘* -> * -> *’,
---     but ‘F s’ has kind ‘(* -> *) -> (* -> *) -> *’
---   In the first argument of ‘MonoidalRep’, namely ‘(F s)’
---   In the instance declaration for ‘MonoidalRep (F s) p’
--- 
--- See notes following MonoidalRep in Category.hs.
-
-#endif

--- a/src/F.hs
+++ b/src/F.hs
@@ -83,7 +83,11 @@ class Linear l where
   -- every operation on every representation is specified by requiring that mu
   -- is homomorphic for (distributes over) that operation. For instance, mu must
   -- be a functor (Category homomorphism).
-  mu :: l s a b -> F s a b
+  mu  :: l s a b -> F s a b
+  -- | Inverse of mu
+  mu' :: F s a b -> l s a b
 
 -- Trivial instance
-instance Linear F where mu = id
+instance Linear F where
+  mu  = id
+  mu' = id

--- a/src/F.hs
+++ b/src/F.hs
@@ -8,7 +8,7 @@ module F where
 
 import Prelude hiding (id,(.),(+),(*),sum)
 
-import GHC.Generics (Par1(..),(:*:)(..),(:.:)(..))
+import GHC.Generics ((:*:)(..),(:.:)(..))
 import Data.Functor.Rep
 
 import Misc
@@ -41,17 +41,17 @@ instance Additive s => Biproduct (F s) (:*:)
 
 instance Semiring s => MonoidalR (F s) where
   cross :: Representable r => r (F s a b) -> F s (r :.: a) (r :.: b)
-  cross fs = F (Comp1 . liftR2 (@@) fs . unComp1)
+  cross fs = F (Comp1 . liftR2 at fs . unComp1)
 
--- The Semiring s constraint here comes from (@@) being in the same class as
+-- The Semiring s constraint here comes from at being in the same class as
 -- scale.
 
 #if 0
                     fs :: r (F s a b)
-        liftR2 (@@) fs :: r (a s) -> r (b s)
-Comp1 . liftR2 (@@) fs . unComp1 :: (r :.: a) s -> (r :.: b) s
+        liftR2 at fs :: r (a s) -> r (b s)
+Comp1 . liftR2 at fs . unComp1 :: (r :.: a) s -> (r :.: b) s
 
-cross = F . inNew (liftR2 (@@))
+cross = F . inNew (liftR2 at)
 #endif
 
 instance Semiring s => CartesianR (F s) where
@@ -80,4 +80,4 @@ oneHot i a = Comp1 (tabulate (\ j -> if i == j then a else zeroV))
 
 instance Semiring s => Linear s F (:*:) where
   scale s = F (fmap (s *))   -- F (\ (Par1 s') -> Par1 (s * s'))
-  (@@) = unF
+  at = unF

--- a/src/F.hs
+++ b/src/F.hs
@@ -79,5 +79,6 @@ oneHot :: (C2 Representable r a, Eq (Rep r), Additive s) => Rep r -> a s -> (r :
 oneHot i a = Comp1 (tabulate (\ j -> if i == j then a else zeroV))
 
 instance Semiring s => Linear s F (:*:) where
-  scale s = F (\ (Par1 s') -> Par1 (s * s'))
+  scale s = F (fmap (s *))
+            -- F (\ (Par1 s') -> Par1 (s * s'))
   F f @@ a = f a

--- a/src/F.hs
+++ b/src/F.hs
@@ -4,7 +4,6 @@
 
 module F where
 
-import qualified Prelude as P
 import Prelude hiding (id,(.))
 
 import GHC.Generics ((:*:)(..))

--- a/src/F.hs
+++ b/src/F.hs
@@ -81,3 +81,10 @@ oneHot i a = Comp1 (tabulate (\ j -> if i == j then a else zeroV))
 instance Semiring s => Linear s F (:*:) where
   scale s = F (fmap (s *))   -- F (\ (Par1 s') -> Par1 (s * s'))
   at = unF
+
+-- | Semantic function for all linear map representations. Correctness of every
+-- operation on every representation is specified by requiring that mu is
+-- homomorphic for that operation. For instance, mu must be a functor (Category
+-- homomorphism).
+mu :: Linear s l p => l s a b -> F s a b
+mu = F . at

--- a/src/F.hs
+++ b/src/F.hs
@@ -1,0 +1,56 @@
+-- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
+
+-- | Linear functions
+--
+-- 
+
+module F where
+
+import qualified Prelude as P
+import Prelude hiding (id,(.))
+
+import GHC.Generics ((:*:)(..))
+import Data.Functor.Rep
+
+import Misc
+import Category
+
+-- | Linear functions
+newtype F (s :: *) a b = F (a s -> b s)
+
+instance Category (F s) where
+  type Obj (F s) = Representable 
+  id = F id
+  F g . F f = F (g . f)
+
+instance Monoidal (F s) (:*:) where
+  F f *** F g = F (\ (a :*: b) -> f a :*: g b)
+
+instance Cartesian (F s) (:*:) where
+  exl = F (\ (a :*: _) -> a)
+  exr = F (\ (_ :*: b) -> b)
+  dup = F (\ a -> a :*: a)
+
+instance Additive s => Cocartesian (F s) (:*:) where
+  inl = F (\ a -> a :*: zeros)
+  inr = F (\ b -> zeros :*: b)
+  jam = F (\ (a :*: b) -> a +^ b)
+
+#if 0
+
+instance Representable p => MonoidalRep (F s) p where
+  -- exs = tabulate (\ i -> F (\ a -> a `index` i))
+  --     = tabulate (\ i -> F (`index` i))
+  --     = tabulate (\ i -> F (flip index i))
+  --     = tabulate (F . flip index)
+
+-- Error:
+-- 
+--   Expected kind ‘* -> * -> *’,
+--     but ‘F s’ has kind ‘(* -> *) -> (* -> *) -> *’
+--   In the first argument of ‘MonoidalRep’, namely ‘(F s)’
+--   In the instance declaration for ‘MonoidalRep (F s) p’
+-- 
+-- See notes following MonoidalRep in Category.hs.
+
+#endif

--- a/src/F.hs
+++ b/src/F.hs
@@ -39,11 +39,8 @@ instance Additive s => Cocartesian (F s) (:*:) where
 
 instance Additive s => Biproduct (F s) (:*:)
 
--- class (Category k, Representable r) => MonoidalR k r where
---   cross :: r (a `k` b) -> ((r :.: a) `k` (r :.: b))
-
-instance (Semiring s) => MonoidalR (F s) where
-  cross :: Representable r => r (F s a b) -> (F s (r :.: a) (r :.: b))
+instance Semiring s => MonoidalR (F s) where
+  cross :: Representable r => r (F s a b) -> F s (r :.: a) (r :.: b)
   cross fs = F (Comp1 . liftR2 (@@) fs . unComp1)
 
 -- The Semiring s constraint here comes from (@@) being in the same class as
@@ -53,6 +50,8 @@ instance (Semiring s) => MonoidalR (F s) where
                     fs :: r (F s a b)
         liftR2 (@@) fs :: r (a s) -> r (b s)
 Comp1 . liftR2 (@@) fs . unComp1 :: (r :.: a) s -> (r :.: b) s
+
+cross = F . inNew (liftR2 (@@))
 #endif
 
 instance Semiring s => CartesianR (F s) where
@@ -75,10 +74,10 @@ instance Semiring s => BiproductR (F s) where
 -- Illegal nested constraint ‘Eq (Rep r)’
 -- (Use UndecidableInstances to permit this)
 
-oneHot :: (C2 Representable r a, Eq (Rep r), Additive s) => Rep r -> a s -> (r :.: a) s
+oneHot :: (C2 Representable r a, Eq (Rep r), Additive s)
+       => Rep r -> a s -> (r :.: a) s
 oneHot i a = Comp1 (tabulate (\ j -> if i == j then a else zeroV))
 
 instance Semiring s => Linear s F (:*:) where
-  scale s = F (fmap (s *))
-            -- F (\ (Par1 s') -> Par1 (s * s'))
+  scale s = F (fmap (s *))   -- F (\ (Par1 s') -> Par1 (s * s'))
   (@@) = unF

--- a/src/InductiveMatrix.hs
+++ b/src/InductiveMatrix.hs
@@ -22,7 +22,8 @@ import Data.Functor.Rep
 
 import Misc
 import Category
-import LinearFunction
+import LinearFunction hiding (L)
+import qualified LinearFunction
 
 -------------------------------------------------------------------------------
 -- | Representation and its denotation

--- a/src/InductiveMatrix.hs
+++ b/src/InductiveMatrix.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
-
 {- |
 "Inductive matrices", as in "Type Your Matrices for Great Good: A Haskell
 Library of Typed Matrices and Applications (Functional Pearl)" Armando Santos
@@ -11,19 +9,14 @@ and José N Oliveira (Haskell Symposium 2020) [URL?]. The main differences:
 
 module InductiveMatrix where
 
--- import qualified Prelude as P
 import Prelude hiding ((+),sum,(*),unzip)
 
-import GHC.Types (Constraint)
 import GHC.Generics (Par1(..), (:*:)(..), (:.:)(..))
-import qualified Control.Arrow as A
-import Data.Distributive
 import Data.Functor.Rep
 
 import Misc
 import Category
 import LinearFunction hiding (L)
-import qualified LinearFunction
 
 -------------------------------------------------------------------------------
 -- | Representation and its denotation
@@ -56,4 +49,3 @@ instance LinearMap L where
 -------------------------------------------------------------------------------
 
 -- instance Category (L s) where ...
-

--- a/src/InductiveMatrix.hs
+++ b/src/InductiveMatrix.hs
@@ -32,7 +32,7 @@ data L :: * -> (* -> *) -> (* -> *) -> * where
   Scale :: Semiring s => s -> L s Par1 Par1
   (:|#) :: (C3 V a b c, Additive s) => L s a c -> L s b c -> L s (a :*: b) c
   (:&#) :: C3 V a c k => L s a c -> L s a k -> L s a (c :*: k)
-  JoinL :: (C2 V a b, Representable r, Foldable r, Additive s)
+  JoinL :: (C2 V a b, Representable r, Eq (Rep r), Foldable r, Additive s)
         => r (L s a b) -> L s (r :.: a) b
   ForkL :: C3 V a b r => r (L s a b) -> L s a (r :.: b)
 

--- a/src/InductiveMatrix.hs
+++ b/src/InductiveMatrix.hs
@@ -1,9 +1,9 @@
 {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
 
-{- | "Inductive matrices", as in "Type Your Matrices for Great Good: A Haskell
+{- |
+"Inductive matrices", as in "Type Your Matrices for Great Good: A Haskell
 Library of Typed Matrices and Applications (Functional Pearl)" Armando Santos
-and José N Oliveira (Haskell Symposium 2020). [TODO: URL]
-The main differences:
+and José N Oliveira (Haskell Symposium 2020) [URL?]. The main differences:
 
 - Representable functors rather than their index types (logarithms).
 - Specified via denotational homomorphisms.
@@ -22,7 +22,7 @@ import Data.Functor.Rep
 
 import Misc
 import Category
-import F
+import LinearFunction
 
 -------------------------------------------------------------------------------
 -- | Representation and its denotation

--- a/src/InductiveMatrix.hs
+++ b/src/InductiveMatrix.hs
@@ -1,0 +1,58 @@
+{-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
+
+{- | "Inductive matrices", as in "Type Your Matrices for Great Good: A Haskell
+Library of Typed Matrices and Applications (Functional Pearl)" Armando Santos
+and José N Oliveira (Haskell Symposium 2020). [TODO: URL]
+The main differences:
+
+- Representable functors rather than their index types (logarithms).
+- Specified via denotational homomorphisms.
+-}
+
+module InductiveMatrix where
+
+-- import qualified Prelude as P
+import Prelude hiding ((+),sum,(*),unzip)
+
+import GHC.Types (Constraint)
+import GHC.Generics (Par1(..), (:*:)(..), (:.:)(..))
+import qualified Control.Arrow as A
+import Data.Distributive
+import Data.Functor.Rep
+
+import Misc
+import Category
+import F
+
+-------------------------------------------------------------------------------
+-- | Representation and its denotation
+-------------------------------------------------------------------------------
+
+infixr 3 :&#
+infixr 2 :|#
+
+type V = Representable
+
+-- | Compositional linear map representation.
+data L :: * -> (* -> *) -> (* -> *) -> * where
+  Scale :: Semiring s => s -> L s Par1 Par1
+  (:|#) :: (C3 V a b c, Additive s) => L s a c -> L s b c -> L s (a :*: b) c
+  (:&#) :: C3 V a c k => L s a c -> L s a k -> L s a (c :*: k)
+  JoinL :: (C2 V a b, Representable r, Foldable r, Additive s)
+        => r (L s a b) -> L s (r :.: a) b
+  ForkL :: C3 V a b r => r (L s a b) -> L s a (r :.: b)
+
+instance LinearMap L where
+  mu (Scale s)  = scale s
+  mu (f :|# g)  = mu f ||| mu g
+  mu (f :&# g)  = mu f &&& mu g
+  mu (JoinL fs) = join (mu <$> fs)
+  mu (ForkL fs) = fork (mu <$> fs)
+  mu' = error "TODO: implement mu' on L"
+
+-------------------------------------------------------------------------------
+-- | Instances (all deducible from denotational homomorphisms)
+-------------------------------------------------------------------------------
+
+-- instance Category (L s) where ...
+

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -289,4 +289,12 @@ isV (ForkL _) = Dict
 
 infixr 9 @.@
 (@.@) :: Semiring s => L b c s -> L a b s -> L a c s
-b @.@ a | (Dict, Dict) <- (isV a, isV b) = b .@ a
+-- b @.@ a | (Dict, Dict) <- (isV a, isV b) = b .@ a
+
+-- b@(isV -> Dict) @.@ a@(isV -> Dict) = b .@ a
+
+pattern IsV :: () => V2 a b => L a b s
+pattern IsV <- (isV -> Dict)
+{-# COMPLETE IsV :: L #-}
+
+b@IsV @.@ a@IsV = b .@ a

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -281,7 +281,7 @@ scaleV s = rowMajToL (diagRep zero (pureRep s))
 
 -- Prove V/Obj constraints from morphisms
 isV :: L a b s -> Dict (V2 a b)
-isV (Scale s) = Dict
+isV (Scale _) = Dict
 isV (_ :|# _) = Dict
 isV (_ :&# _) = Dict
 isV (JoinL _) = Dict

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -286,3 +286,7 @@ isV (_ :|# _) = Dict
 isV (_ :&# _) = Dict
 isV (JoinL _) = Dict
 isV (ForkL _) = Dict
+
+infixr 9 @.@
+(@.@) :: Semiring s => L b c s -> L a b s -> L a c s
+b @.@ a | (Dict, Dict) <- (isV a, isV b) = b .@ a

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -1,8 +1,10 @@
+-- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
+
 -- | Linear algebra after Fortran
 
 module LinAlg where
 
-import qualified Prelude as P
+-- import qualified Prelude as P
 import Prelude hiding ((+),sum,(*),unzip)
 
 import GHC.Generics (Par1(..), (:*:)(..), (:.:)(..))
@@ -10,39 +12,11 @@ import qualified Control.Arrow as A
 import Data.Distributive
 import Data.Functor.Rep
 
-infixl 7 :*
-type (:*)  = (,)
-
--- infixl 6 :+
--- type (:+)  = Either
-
-unzip :: Functor f => f (a :* b) -> f a :* f b
-unzip ps = (fst <$> ps, snd <$> ps)
+import Misc
 
 type V f = (Representable f, Foldable f, Eq (Rep f))
 type V2 f g = (V f, V g)
 type V3 f g h = (V2 f g, V h)
-
-class Additive a where
-  infixl 6 +
-  zero :: a
-  (+) :: a -> a -> a
-
-class Additive a => Semiring a where
-  infixl 7 *
-  one :: a
-  (*) :: a -> a -> a
-
-sum :: (Foldable f, Additive a) => f a -> a
-sum = foldr (+) zero
-
--- | Vector addition
-infixl 6 +^
-(+^) :: (Representable f, Additive s) => f s -> f s -> f s
-(+^) = liftR2 (+)
-
-instance Additive Double where { zero = 0; (+) = (P.+) }
-instance Semiring Double where { one  = 1; (*) = (P.*) }
 
 infixr 3 :&#
 infixr 2 :|#

--- a/src/LinAlg.hs
+++ b/src/LinAlg.hs
@@ -13,6 +13,9 @@ import qualified Control.Arrow as A
 import Data.Distributive
 import Data.Functor.Rep
 
+-- Experiment
+import Data.Constraint (Dict(..))
+
 import Misc
 
 type V f = ((Representable f, Foldable f, Eq (Rep f), ToScalar f, ToRowMajor f)
@@ -24,8 +27,12 @@ type V4 f g h k = (V2 f g, V2 h k)
 -- TODO: Why does V suddenly need ":: Constraint" after adding ToScalar f and
 -- ToRowMajor f?
 
-type V3f f g h = (V2 f g, Representable h)  -- for n-ary forks
-type V3j f g h = (V3f f g h, Foldable h)    -- for n-ary joins
+-- type V3f f g h = (V2 f g, Representable h)  -- for n-ary forks
+-- type V3j f g h = (V3f f g h, Foldable h)    -- for n-ary joins
+
+-- For the isV experiment below, I need more.
+type V3f f g h = V3 f g h  -- for n-ary forks
+type V3j f g h = V3 f g h  -- for n-ary joins
 
 infixr 3 :&#
 infixr 2 :|#
@@ -268,3 +275,14 @@ zeroL = rowMajToL (pureRep (pureRep zero))
 -- Vector scaling
 scaleV :: (V a, Additive s) => s -> L a a s
 scaleV s = rowMajToL (diagRep zero (pureRep s))
+
+
+-- -- Experiment
+
+-- Prove V/Obj constraints from morphisms
+isV :: L a b s -> Dict (V2 a b)
+isV (Scale s) = Dict
+isV (_ :|# _) = Dict
+isV (_ :&# _) = Dict
+isV (JoinL _) = Dict
+isV (ForkL _) = Dict

--- a/src/LinearFunction.hs
+++ b/src/LinearFunction.hs
@@ -4,7 +4,7 @@
 -- | Linear functions, providing denotational specification for all linear map
 -- representations.
 
-module F where
+module LinearFunction where
 
 import Prelude hiding (id,(.),(+),(*),sum)
 

--- a/src/LinearFunction.hs
+++ b/src/LinearFunction.hs
@@ -15,56 +15,56 @@ import Misc
 import Category
 
 -- | Linear functions
-newtype F (s :: *) a b = F { unF :: a s -> b s }
+newtype L (s :: *) a b = L { unF :: a s -> b s }
 
-instance Category (F s) where
-  type Obj' (F s) = Representable 
-  id = F id
-  F g . F f = F (g . f)
+instance Category (L s) where
+  type Obj' (L s) = Representable 
+  id = L id
+  L g . L f = L (g . f)
 
-instance Monoidal (F s) (:*:) where
-  F f *** F g = F (\ (a :*: b) -> f a :*: g b)
+instance Monoidal (L s) (:*:) where
+  L f *** L g = L (\ (a :*: b) -> f a :*: g b)
 
-instance Cartesian (F s) (:*:) where
-  exl = F exlF
-  exr = F exrF
-  dup = F dupF
+instance Cartesian (L s) (:*:) where
+  exl = L exlF
+  exr = L exrF
+  dup = L dupF
 
-instance Comonoidal (F s) (:*:) where (+++) = (***)
+instance Comonoidal (L s) (:*:) where (+++) = (***)
 
-instance Additive s => Cocartesian (F s) (:*:) where
-  inl = F (:*: zeroV)
-  inr = F (zeroV :*:)
-  jam = F (uncurryF (+^))
+instance Additive s => Cocartesian (L s) (:*:) where
+  inl = L (:*: zeroV)
+  inr = L (zeroV :*:)
+  jam = L (uncurryF (+^))
 
-instance Additive s => Biproduct (F s) (:*:)
+instance Additive s => Biproduct (L s) (:*:)
 
-instance MonoidalR (F s) where
-  cross :: Representable r => r (F s a b) -> F s (r :.: a) (r :.: b)
-  cross fs = F (Comp1 . liftR2 unF fs . unComp1)
+instance MonoidalR (L s) where
+  cross :: Representable r => r (L s a b) -> L s (r :.: a) (r :.: b)
+  cross fs = L (Comp1 . liftR2 unF fs . unComp1)
 
 #if 0
-                   fs :: r (F s a b)
+                   fs :: r (L s a b)
         liftR2 unF fs :: r (a s) -> r (b s)
 Comp1 . liftR2 unF fs . unComp1 :: (r :.: a) s -> (r :.: b) s
 
-cross = F . inNew (liftR2 unF)
+cross = L . inNew (liftR2 unF)
 #endif
 
-instance CartesianR (F s) where
-  exs :: Representable r => r (F s (r :.: a) a)
-  exs = tabulate (\ i -> F (\ (Comp1 as) -> as `index` i))
-  dups :: Representable r => F s a (r :.: a)
-  dups = F (\ a -> Comp1 (pureRep a))
-         -- F (Comp1 . pureRep)
+instance CartesianR (L s) where
+  exs :: Representable r => r (L s (r :.: a) a)
+  exs = tabulate (\ i -> L (\ (Comp1 as) -> as `index` i))
+  dups :: Representable r => L s a (r :.: a)
+  dups = L (\ a -> Comp1 (pureRep a))
+         -- L (Comp1 . pureRep)
 
-instance Additive s => BiproductR (F s) where
-  ins :: (C2 Representable r a, Eq (Rep r)) => r (F s a (r :.: a))
-  ins = tabulate (F . oneHot)
-        -- tabulate $ \ i -> F (oneHot i)
-        -- tabulate $ \ i -> F (\ a -> oneHot i a)
-  jams :: (C2 Representable r a, Foldable r) => F s (r :.: a) a
-  jams = F (\ (Comp1 as) -> foldr (+^) zeroV as)
+instance Additive s => BiproductR (L s) where
+  ins :: (C2 Representable r a, Eq (Rep r)) => r (L s a (r :.: a))
+  ins = tabulate (L . oneHot)
+        -- tabulate $ \ i -> L (oneHot i)
+        -- tabulate $ \ i -> L (\ a -> oneHot i a)
+  jams :: (C2 Representable r a, Foldable r) => L s (r :.: a) a
+  jams = L (\ (Comp1 as) -> foldr (+^) zeroV as)
 
 -- TODO: can we define ins without Eq (Rep r)?
 
@@ -78,19 +78,19 @@ oneHot i a = Comp1 (tabulate (\ j -> if i == j then a else zeroV))
 class Scalable l where
   scale :: Semiring s => s -> l s Par1 Par1
 
-instance Scalable F where
-  scale s = F (fmap (s *))   -- F (\ (Par1 s') -> Par1 (s * s'))
+instance Scalable L where
+  scale s = L (fmap (s *))   -- L (\ (Par1 s') -> Par1 (s * s'))
 
 class LinearMap l where
   -- | Semantic function for all linear map representations. Correctness of
   -- every operation on every representation is specified by requiring that mu
   -- is homomorphic for (distributes over) that operation. For instance, mu must
   -- be a functor (Category homomorphism).
-  mu  :: l s a b -> F s a b
+  mu  :: l s a b -> L s a b
   -- | Inverse of mu
-  mu' :: F s a b -> l s a b
+  mu' :: L s a b -> l s a b
 
 -- Trivial instance
-instance LinearMap F where
+instance LinearMap L where
   mu  = id
   mu' = id

--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -51,20 +51,20 @@ class Additive a => Semiring a where
   one :: a
   (*) :: a -> a -> a
 
+instance Additive Double where { zero = 0; (+) = (P.+) }
+instance Semiring Double where { one  = 1; (*) = (P.*) }
+
 sum :: (Foldable f, Additive a) => f a -> a
 sum = foldr (+) zero
 
 -- Zero vector
-zeros :: (Representable a, Additive s) => a s
-zeros = pureRep zero
+zeroV :: (Representable a, Additive s) => a s
+zeroV = pureRep zero
 
 -- | Vector addition
 infixl 6 +^
 (+^) :: (Representable f, Additive s) => f s -> f s -> f s
 (+^) = liftR2 (+)
-
-instance Additive Double where { zero = 0; (+) = (P.+) }
-instance Semiring Double where { one  = 1; (*) = (P.*) }
 
 -- Miscellany
 

--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -1,0 +1,72 @@
+-- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
+
+-- | Miscellany
+
+module Misc where
+
+import qualified Prelude as P
+import Prelude hiding ((+),sum,(*),unzip)
+import GHC.Types (Constraint)
+
+import Data.Functor.Rep
+
+-- More convenient type notation
+
+infixl 7 :*
+type (:*)  = (,)
+
+infixl 6 :+
+type (:+)  = Either
+
+
+-- Constraint helpers
+
+#if 1
+-- Experiment. Smaller Core?
+type C1 (con :: u -> Constraint) a = con a
+type C2 (con :: u -> Constraint) a b = (con a, con b)
+type C3 (con :: u -> Constraint) a b c = (con a, con b, con c)
+type C4 (con :: u -> Constraint) a b c d = (con a, con b, con c, con d)
+type C5 (con :: u -> Constraint) a b c d e = (con a, con b, con c, con d, con e)
+type C6 (con :: u -> Constraint) a b c d e f = (con a, con b, con c, con d, con e, con f)
+#else
+type C1 (con :: u -> Constraint) a = con a
+type C2 con a b         = (C1 con a, con b)
+type C3 con a b c       = (C2 con a b, con c)
+type C4 con a b c d     = (C2 con a b, C2 con c d)
+type C5 con a b c d e   = (C3 con a b c, C2 con d e)
+type C6 con a b c d e f = (C3 con a b c, C3 con d e f)
+#endif
+
+
+-- Semirings
+
+class Additive a where
+  infixl 6 +
+  zero :: a
+  (+) :: a -> a -> a
+
+class Additive a => Semiring a where
+  infixl 7 *
+  one :: a
+  (*) :: a -> a -> a
+
+sum :: (Foldable f, Additive a) => f a -> a
+sum = foldr (+) zero
+
+-- Zero vector
+zeros :: (Representable a, Additive s) => a s
+zeros = pureRep zero
+
+-- | Vector addition
+infixl 6 +^
+(+^) :: (Representable f, Additive s) => f s -> f s -> f s
+(+^) = liftR2 (+)
+
+instance Additive Double where { zero = 0; (+) = (P.+) }
+instance Semiring Double where { one  = 1; (*) = (P.*) }
+
+-- Miscellany
+
+unzip :: Functor f => f (a :* b) -> f a :* f b
+unzip ps = (fst <$> ps, snd <$> ps)

--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -57,6 +57,9 @@ instance Semiring Double where { one  = 1; (*) = (P.*) }
 sum :: (Foldable f, Additive a) => f a -> a
 sum = foldr (+) zero
 
+-- To do: maybe replace `foldr` by `foldl` or `foldl'`. Does a strict left fold
+-- help at all, considering that our "vectors" aren't flat?
+
 -- Zero vector
 zeroV :: (Representable a, Additive s) => a s
 zeroV = pureRep zero


### PR DESCRIPTION
This PR is work in progress, but I want to share what I’m up to.

I started a new module (currently called “`F`”) with a definition of linear functions as part of a denotational specification of `L`. I want to use a shared vocabulary, so I’m also working on some category classes that are poly-kinded (to accommodate the functor categories we’ll need) and have associated constraints, products, and coproducts. Going okay so far, but we’ll see how type inference works out.

The specification will include a “semantic function” mapping our `L` type to linear functions, plus the requirement that this semantic function is homomorphic for *all* of the vocabulary we use. I expect this discipline to give us a precise, regular, and intuitively helpful specification of all we do, with which we can calculate and/or prove our implementation code.

Still to come:

  - Adapt `L` to use this vocabulary.
  - Solve a typing puzzle with n-ary products and coproducts (noted in code).
  - Rename modules, maybe adding a module name-space level (e.g., “`LinAlg.L`”).
  - Define the semantic function, which should be very pretty, due to the homomorphisms and the close relationship of the `L` representation with the vocabulary.
  - Demonstrate some code calculations.
  - `Representable` instances for linear functions and for `L`. As with all other interfaces, the semantic function for `L` must be a `Representable` homomorphism. See \#26 for discussion.

I won’t merge until at least the first two steps are done.

Comments & questions most welcome\!
