### PR TITLE
default-extensions

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -4,8 +4,13 @@ github:              "conal/linalg"
 
 description:         Please see the README on GitHub at <https://github.com/conal/linalg>
 
+# Common language extensions defining the default language for the project.
+# Un-comment each extension the first time it's used in a module.
+# UndecidableInstances and AllowAmbiguousTypes instead go in the modules with
+# a corresponding GHC error comment right after the code that generates the
+# warning. See LinAlg for an example.
+
 default-extensions:
-  # - AllowAmbiguousTypes
   - CPP
   - ConstraintKinds
   # - DefaultSignatures
@@ -13,26 +18,24 @@ default-extensions:
   # - DeriveFunctor
   - FlexibleContexts
   - FlexibleInstances
-  # - FunctionalDependencies
+  - FunctionalDependencies
   - GADTs
   # - GeneralizedNewtypeDeriving
   # - LambdaCase
-  # - MultiParamTypeClasses
-  # - OverloadedStrings  # for Poly, since dante doesn't pick up
+  - MultiParamTypeClasses
   - PatternSynonyms
   # - QuantifiedConstraints
   # - RankNTypes
   # - StandaloneDeriving
   # - TupleSections
   - TypeApplications
-  # - TypeFamilies
+  - TypeFamilies
   - TypeOperators
-  # - UndecidableInstances
   - ViewPatterns
   # - ScopedTypeVariables
   - KindSignatures
-  # - NoStarIsType
   - TypeSynonymInstances
+  - PolyKinds
 
 ghc-options:
   -Wall


### PR DESCRIPTION
Explanation of project-wide vs per-module language extensions