### PR TITLE
Better n-ary/representable classes

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,8 @@ default-extensions:
   - ConstraintKinds
   # - DefaultSignatures
   # - DeriveFoldable
-  # - DeriveFunctor
+  - DeriveFunctor
+  - DeriveGeneric
   - FlexibleContexts
   - FlexibleInstances
   - FunctionalDependencies

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -334,11 +334,11 @@ instance ComonoidalR k r p => MonoidalR (Op k) r p where
 instance MonoidalR k r p => ComonoidalR (Op k) r p where
   plus (fmap unOp -> fs) = Op (cross fs)
 
-instance (MonoidalR k r p, CocartesianR k r p) => CartesianR (Op k) r p where
+instance CocartesianR k r p => CartesianR (Op k) r p where
   exs  = Op <$> ins
   dups = Op jams
 
-instance (MonoidalR k r p, CartesianR k r p) => CocartesianR (Op k) r p where
+instance CartesianR k r p => CocartesianR (Op k) r p where
   ins  = Op <$> exs
   jams = Op dups
 

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -245,6 +245,9 @@ instance Cocartesian (->) (:+) where
 newtype Ap f a = Ap { unAp :: f a }
   deriving (Functor, Generic, Generic1)
 
+-- TODO: switch to Data.Monoid.Ap if/when it gets Distributive and Representable
+-- instances.
+
 instance Distributive f => Distributive (Ap f) where
   distribute = Ap . distribute . fmap unAp
 
@@ -331,7 +334,12 @@ instance ComonoidalR k r p => MonoidalR (Op k) r p where
 instance MonoidalR k r p => ComonoidalR (Op k) r p where
   plus (fmap unOp -> fs) = Op (cross fs)
 
-
 instance (MonoidalR k r p, CocartesianR k r p) => CartesianR (Op k) r p where
   exs  = Op <$> ins
   dups = Op jams
+
+instance (MonoidalR k r p, CartesianR k r p) => CocartesianR (Op k) r p where
+  ins  = Op <$> exs
+  jams = Op dups
+
+instance BiproductR k r p => BiproductR (Op k) r p

--- a/src/InductiveMatrix.hs
+++ b/src/InductiveMatrix.hs
@@ -48,4 +48,7 @@ instance LinearMap L where
 -- | Instances (all deducible from denotational homomorphisms)
 -------------------------------------------------------------------------------
 
--- instance Category (L s) where ...
+instance Category (L s) where
+  type Obj' (L s) = V
+  id = undefined
+  (.) = undefined

--- a/src/LinearFunction.hs
+++ b/src/LinearFunction.hs
@@ -39,8 +39,8 @@ instance Additive s => Cocartesian (L s) (:*:) where
 
 instance Additive s => Biproduct (L s) (:*:)
 
-instance Representable r => MonoidalR (L s) r where
-  cross :: r (L s a b) -> L s (r :.: a) (r :.: b)
+instance Representable r => MonoidalR (L s) r (:.:) where
+  cross :: Obj2 (L s) a b => r (L s a b) -> L s (r :.: a) (r :.: b)
   cross fs = L (Comp1 . liftR2 unF fs . unComp1)
 
 #if 0
@@ -51,20 +51,22 @@ Comp1 . liftR2 unF fs . unComp1 :: (r :.: a) s -> (r :.: b) s
 cross = L . inNew (liftR2 unF)
 #endif
 
-instance Representable r => CartesianR (L s) r where
-  exs :: r (L s (r :.: a) a)
+instance Representable r => CartesianR (L s) r (:.:) where
+  exs :: Obj (L s) a => r (L s (r :.: a) a)
   exs = tabulate (\ i -> L (\ (Comp1 as) -> as `index` i))
-  dups :: L s a (r :.: a)
-  dups = L (\ a -> Comp1 (pureRep a))
-         -- L (Comp1 . pureRep)
+  dups :: Obj (L s) a => L s a (r :.: a)
+  dups = L (Comp1 . pureRep)
+
+instance Representable r => ComonoidalR (L s) r (:.:) where
+  plus = cross
 
 instance (Additive s, Representable r, Eq (Rep r), Foldable r)
-      => BiproductR (L s) r where
-  ins :: Representable a => r (L s a (r :.: a))
+      => CocartesianR (L s) r (:.:) where
+  ins :: Obj (L s) a => r (L s a (r :.: a))
   ins = tabulate (L . oneHot)
         -- tabulate $ \ i -> L (oneHot i)
         -- tabulate $ \ i -> L (\ a -> oneHot i a)
-  jams :: Representable a => L s (r :.: a) a
+  jams :: Obj (L s) a => L s (r :.: a) a
   jams = L (\ (Comp1 as) -> foldr (+^) zeroV as)
 
 -- TODO: can we define ins without Eq (Rep r)?
@@ -72,7 +74,7 @@ instance (Additive s, Representable r, Eq (Rep r), Foldable r)
 -- Illegal nested constraint ‘Eq (Rep r)’
 -- (Use UndecidableInstances to permit this)
 
-oneHot :: (C2 Representable a r, Eq (Rep r), Additive s)
+oneHot :: (Obj (L s) a, Representable r, Eq (Rep r), Additive s)
        => Rep r -> a s -> (r :.: a) s
 oneHot i a = Comp1 (tabulate (\ j -> if i == j then a else zeroV))
 
@@ -87,9 +89,9 @@ class LinearMap l where
   -- every operation on every representation is specified by requiring that mu
   -- is homomorphic for (distributes over) that operation. For instance, mu must
   -- be a functor (Category homomorphism).
-  mu  :: l s a b -> L s a b
+  mu  :: Obj2 (l s) a b => l s a b -> L s a b
   -- | Inverse of mu
-  mu' :: L s a b -> l s a b
+  mu' :: Obj2 (l s) a b => L s a b -> l s a b
 
 -- Trivial instance
 instance LinearMap L where


### PR DESCRIPTION
Now poly-kinded, more sensibly defined, exhibit the usual product/coproduct dualities, and mirror their binary counterparts. I mostly used [Dan's formulation](https://github.com/conal/linalg/pull/28#discussion_r465142333) but changed the `ComonoidalR` and `CocartesianR` instances of `LinearFunction.L` so that (a) their operations are linear and (b) linear functions form a biproduct category.