### PR TITLE
Use DerivingVia instead of cpp

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -17,6 +17,7 @@ default-extensions:
   # - DeriveFoldable
   - DeriveFunctor
   - DeriveGeneric
+  - DerivingVia
   - FlexibleContexts
   - FlexibleInstances
   - FunctionalDependencies

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -36,6 +36,7 @@ instance Obj' k a => Obj k a
 
 class Category (k :: u -> u -> *) where
   type Obj' k :: u -> Constraint
+  type instance Obj' k = Unconstrained
   infixr 9 .
   id :: Obj k a => a `k` a
   (.) :: Obj3 k a b c => (b `k` c) -> (a `k` b) -> (a `k` c)
@@ -55,9 +56,9 @@ type Obj6 k a b c d e f = C6 (Obj k) a b c d e f
 
 -- Products of objects are objects.
 -- Seee https://github.com/conal/linalg/pull/28#issuecomment-670313952
-type ObjBin k p = ((forall a b. Obj2 k a b => Obj k (a `p` b)) :: Constraint)
+type ObjBin p k = ((forall a b. Obj2 k a b => Obj k (a `p` b)) :: Constraint)
 
-class (Category k, ObjBin k p) => Monoidal k p | k -> p where
+class (Category k, ObjBin p k) => Monoidal p k | k -> p where
   infixr 3 ***
   (***) :: Obj4 k a b c d => (a `k` c) -> (b `k` d) -> ((a `p` b) `k` (c `p` d))
 
@@ -85,29 +86,29 @@ class (Category k, ObjBin k p) => Monoidal k p | k -> p where
 -- we cannot currently handle n-ary coproducts that are not n-ary cartesian
 -- *products*.
 
-first :: (Monoidal k p, Obj3 k a b c) => (a `k` c) -> ((a `p` b) `k` (c `p` b))
+first :: (Monoidal p k, Obj3 k a b c) => (a `k` c) -> ((a `p` b) `k` (c `p` b))
 first f = f *** id
 
-second :: (Monoidal k p, Obj3 k a b d) => (b `k` d) -> ((a `p` b) `k` (a `p` d))
+second :: (Monoidal p k, Obj3 k a b d) => (b `k` d) -> ((a `p` b) `k` (a `p` d))
 second g = id *** g
 
-class Monoidal k p => Cartesian k p where
+class Monoidal p k => Cartesian p k where
   exl :: Obj2 k a b => (a `p` b) `k` a
   exr :: Obj2 k a b => (a `p` b) `k` b
   dup :: Obj  k a   => a `k` (a `p` a)
 
 -- Binary fork
 infixr 3 &&&
-(&&&) :: (Cartesian k p, Obj3 k a c d)
+(&&&) :: (Cartesian p k, Obj3 k a c d)
       => (a `k` c) -> (a `k` d) -> (a `k` (c `p` d))
 f &&& g = (f *** g) . dup
 
-fork2 :: (Cartesian k p, Obj3 k a c d)
+fork2 :: (Cartesian p k, Obj3 k a c d)
       => (a `k` c) :* (a `k` d) -> (a `k` (c `p` d))
 fork2 = uncurry (&&&)
 
 -- Inverse of fork2
-unfork2 :: (Cartesian k p, Obj3 k a c d)
+unfork2 :: (Cartesian p k, Obj3 k a c d)
         => (a `k` (c `p` d)) -> ((a `k` c) :* (a `k` d))
 unfork2 f = (exl . f , exr . f)
 
@@ -117,53 +118,24 @@ unfork2 f = (exl . f , exr . f)
 -- defaults, and give defaults for exl, exr, and dup in terms of (&&&) and
 -- unfork2. Use MINIMAL pragmas.
 
-pattern (:&) :: (Cartesian k p, Obj3 k a c d)
+pattern (:&) :: (Cartesian p k, Obj3 k a c d)
              => (a `k` c) -> (a `k` d) -> (a `k` (c `p` d))
 pattern f :& g <- (unfork2 -> (f,g)) where (:&) = (&&&)
 -- {-# complete (:&) #-}
 
 -- GHC error:
--- 
+--
 --   A type signature must be provided for a set of polymorphic pattern synonyms.
 --   In {-# complete :& #-}
 --
 -- Instead, give a typed COMPLETE pragma with each cartesian category instance.
 
-#define AssociativeDefaultCartesian
-
-class Associative k p where
+class Associative p k where
   lassoc :: Obj3 k a b c => (a `p` (b `p` c)) `k` ((a `p` b) `p` c)
   rassoc :: Obj3 k a b c => ((a `p` b) `p` c) `k` (a `p` (b `p` c))
-  -- GHC lets us default via Cartesian or Cocartesian, but not both. We could
-  -- split Associative (and Symmetric) into product and coproduct variants to
-  -- get both defaults.
-#ifdef AssociativeDefaultCartesian
-  default lassoc :: (Cartesian k p, Obj3 k a b c)
-                 => (a `p` (b `p` c)) `k` ((a `p` b) `p` c)
-  lassoc = second exl &&& (exr . exr)
-  default rassoc :: (Cartesian k p, Obj3 k a b c)
-                 => ((a `p` b) `p` c) `k` (a `p` (b `p` c))
-  rassoc = (exl . exl) &&& first  exr
-#else
-  default lassoc :: (Cocartesian k p, Obj3 k a b c)
-                 => (a `p` (b `p` c)) `k` ((a `p` b) `p` c)
-  lassoc = inl.inl ||| (inl.inr ||| inr)
-  default rassoc :: (Cocartesian k p, Obj3 k a b c)
-                 => ((a `p` b) `p` c) `k` (a `p` (b `p` c))
-  rassoc = (inl ||| inr.inl) ||| inr.inr
-#endif
 
--- #define SymmetricDefaultCartesian
-
-class Symmetric k p where
+class Symmetric p k where
   swap :: Obj2 k a b => (a `p` b) `k` (b `p` a)
-#ifdef SymmetricDefaultCartesian
-  default swap :: (Cartesian k p, Obj2 k a b) => (a `p` b) `k` (b `p` a)
-  swap = exr &&& exl
-#else
-  default swap :: (Cocartesian k p, Obj2 k a b) => (a `p` b) `k` (b `p` a)
-  swap = inr ||| inl
-#endif
 
 -- TODO: Maybe split Symmetric into Braided and Symmetric, with the latter
 -- having an extra law. Maybe Associative as Braided superclass. See
@@ -171,7 +143,8 @@ class Symmetric k p where
 -- Note that Associative is a superclass of Monoidal in
 -- <https://hackage.haskell.org/package/categories/docs/Control-Category-Monoidal.html>.
 
-class (Category k, ObjBin k co) => Comonoidal k co | k -> co where
+
+class (Category k, ObjBin co k) => Comonoidal co k | k -> co where
   infixr 2 +++
   (+++) :: Obj4 k a b c d => (a `k` c) -> (b `k` d) -> ((a `co` b) `k` (c `co` d))
 
@@ -185,23 +158,23 @@ class (Category k, ObjBin k co) => Comonoidal k co | k -> co where
 -- *  Is type inference manageable without these functional dependencies?
 -- *  What to call the operation that unifies (***) and (+++)?
 
-class Comonoidal k co => Cocartesian k co where
+class Comonoidal co k => Cocartesian co k where
   inl :: Obj2 k a b => a `k` (a `co` b)
   inr :: Obj2 k a b => b `k` (a `co` b)
   jam :: Obj  k a   => (a `co` a) `k` a
 
 -- Binary join
 infixr 2 |||
-(|||) :: (Cocartesian k co, Obj3 k a b c)
+(|||) :: (Cocartesian co k, Obj3 k a b c)
       => (a `k` c) -> (b `k` c) -> ((a `co` b) `k` c)
 f ||| g = jam . (f +++ g)
 
-join2 :: (Cocartesian k co, Obj3 k a b c)
+join2 :: (Cocartesian co k, Obj3 k a b c)
       => (a `k` c) :* (b `k` c) -> ((a `co` b) `k` c)
 join2 = uncurry (|||)
 
 -- Inverse of join2
-unjoin2 :: (Cocartesian k co, Obj3 k a b c)
+unjoin2 :: (Cocartesian co k, Obj3 k a b c)
         => ((a `co` b) `k` c) -> ((a `k` c) :* (b `k` c))
 unjoin2 f = (f . inl , f . inr)
 
@@ -211,16 +184,50 @@ unjoin2 f = (f . inl , f . inr)
 -- defaults, and give defaults for exl, exr, and dup in terms of (|||) and
 -- unjoin2. Use MINIMAL pragmas.
 
-pattern (:|) :: (Cocartesian k co, Obj3 k a b c)
+pattern (:|) :: (Cocartesian co k, Obj3 k a b c)
              => (a `k` c) -> (b `k` c) -> ((a `co` b) `k` c)
 pattern f :| g <- (unjoin2 -> (f,g)) where (:|) = (|||)
 -- {-# complete (:|) #-}  -- See (:&) above
 
-type Bicartesian k p co = (Cartesian k p, Cocartesian k co)
+type Bicartesian p co k = (Cartesian p k, Cocartesian co k)
 
 -- When products and coproducts coincide. A class rather than type synonym,
 -- because there are more laws.
-class Bicartesian k p p => Biproduct k p
+class Bicartesian p p k => Biproduct p k
+
+
+-- | The 'ViaCartesian' type is designed to be used with `DerivingVia` to derive
+-- `Associative` and `Symmetric` instances using the `Cartesian` operations.
+newtype ViaCartesian p k a b = ViaCartesian (k a b)
+instance Category k => Category (ViaCartesian p k) where
+  type Obj' (ViaCartesian p k) = Obj k
+  id = ViaCartesian id
+  ViaCartesian g . ViaCartesian f = ViaCartesian (g . f)
+deriving instance Monoidal  p k => Monoidal  p (ViaCartesian p k)
+deriving instance Cartesian p k => Cartesian p (ViaCartesian p k)
+
+instance Cartesian p k => Associative p (ViaCartesian p k) where
+  lassoc = second exl &&& (exr . exr)
+  rassoc = (exl . exl) &&& first  exr
+instance Cartesian p k => Symmetric p (ViaCartesian p k) where
+  swap = exr &&& exl
+
+-- | The 'ViaCocartesian' type is designed to be used with `DerivingVia` to derive
+-- `Associative` and `Symmetric` instances using the `Cocartesian` operations.
+newtype ViaCocartesian co k a b = ViaCocartesian (k a b)
+instance Category k => Category (ViaCocartesian p k) where
+  type Obj' (ViaCocartesian p k) = Obj k
+  id = ViaCocartesian id
+  ViaCocartesian g . ViaCocartesian f = ViaCocartesian (g . f)
+deriving instance Comonoidal  co k => Comonoidal  co (ViaCocartesian co k)
+deriving instance Cocartesian co k => Cocartesian co (ViaCocartesian co k)
+
+instance Cocartesian co k => Associative co (ViaCocartesian co k) where
+  lassoc = inl.inl ||| (inl.inr ||| inr)
+  rassoc = (inl ||| inr.inl) ||| inr.inr
+instance Cocartesian co k => Symmetric co (ViaCocartesian co k) where
+  swap = inr ||| inl
+
 
 -------------------------------------------------------------------------------
 -- | n-ary counterparts (where n is a type, not a number).
@@ -229,49 +236,49 @@ class Bicartesian k p p => Biproduct k p
 -- Assumes functor categories. To do: look for a clean, poly-kinded alternative.
 -- I guess we could generalize from functor composition and functor application.
 
-type ObjR' k r p = ((forall z. Obj k z => Obj k (p r z)) :: Constraint)
+type ObjR' r p k = ((forall z. Obj k z => Obj k (p r z)) :: Constraint)
 
-class    (Functor r, ObjR' k r p) => ObjR k r p
-instance (Functor r, ObjR' k r p) => ObjR k r p
+class    (Functor r, ObjR' r p k) => ObjR r p k
+instance (Functor r, ObjR' r p k) => ObjR r p k
 
-class (Category k, ObjR k r p) => MonoidalR k r p | k r -> p where
+class (Category k, ObjR r p k) => MonoidalR r p k | k r -> p where
   cross :: Obj2 k a b => r (a `k` b) -> (p r a `k` p r b)
 
-class MonoidalR k r p => CartesianR k r p where
+class MonoidalR r p k => CartesianR r p k where
   exs  :: Obj k a => r (p r a `k` a)
   dups :: Obj k a => a `k` p r a
 
-fork :: (CartesianR k r p, Obj2 k a c) => r (a `k` c) -> (a `k` p r c)
+fork :: (CartesianR r p k, Obj2 k a c) => r (a `k` c) -> (a `k` p r c)
 fork fs = cross fs . dups
 
-unfork :: (CartesianR k r p, Obj2 k a b) => a `k` (p r b) -> r (a `k` b)
+unfork :: (CartesianR r p k, Obj2 k a b) => a `k` (p r b) -> r (a `k` b)
 unfork f = (. f) <$> exs
 
 -- Exercise: Prove that fork and unfork form an isomorphism.
 
-class (Category k, ObjR k r co) => ComonoidalR k r co | k r -> co where
+class (Category k, ObjR r co k) => ComonoidalR r co k | k r -> co where
   plus :: Obj2 k a b => r (a `k` b) -> (co r a `k` co r b)
 
 -- N-ary biproducts
-class ComonoidalR k r co => CocartesianR k r co where
+class ComonoidalR r co k => CocartesianR r co k where
   ins  :: Obj k a => r (a `k` co r a)
   jams :: Obj k a => co r a `k` a
 
-join :: (CocartesianR k r co, Obj2 k a b) => r (a `k` b) -> co r a `k` b
+join :: (CocartesianR r co k, Obj2 k a b) => r (a `k` b) -> co r a `k` b
 join fs = jams . plus fs
 
-unjoin :: (CocartesianR k r co, Obj2 k a b) => co r a `k` b -> r (a `k` b)
+unjoin :: (CocartesianR r co k, Obj2 k a b) => co r a `k` b -> r (a `k` b)
 unjoin f = (f .) <$> ins
 
 -- TODO: Add fork & unfork to CartesianR with the current definitions as
 -- defaults, and give defaults for exs and dups in terms of fork and unfork.
 -- Ditto for ins/jams and join/unjoin. Use MINIMAL pragmas.
 
-type BicartesianR k r p co = (CartesianR k r p, CocartesianR k r co)
+type BicartesianR r p co k = (CartesianR r p k, CocartesianR r co k)
 
 -- When products and coproducts coincide. A class rather than type synonym,
 -- because there are more laws.
-class BicartesianR k r p p => BiproductR k r p
+class BicartesianR r p p k => BiproductR r p k
 
 -- Add Abelian and AbelianR?
 -- I think f + g = jam . (f &&& g), and sum fs = jams . fork fs.
@@ -281,55 +288,33 @@ class BicartesianR k r p p => BiproductR k r p
 -------------------------------------------------------------------------------
 
 instance Category (->) where
-  type Obj' (->) = Unconstrained
   id = P.id
   (.) = (P..)
 
-instance Monoidal (->) (:*) where
+instance Monoidal (:*) (->) where
   (***) = (A.***)
 
-instance Associative (->) (:*) where
-#ifndef AssociativeDefaultCartesian
-  lassoc (a,(b,c)) = ((a,b),c)
-  rassoc ((a,b),c) = (a,(b,c))
-#endif
-
-instance Symmetric (->) (:*) where
-#ifndef SymmetricDefaultCartesian
-  swap (a,b) = (b,a)
-#endif
-
-instance Cartesian (->) (:*) where
+instance Cartesian (:*) (->) where
   exl = fst
   exr = snd
   dup = \ a -> (a,a)
 
-instance Comonoidal (->) (:+) where
+instance Comonoidal (:+) (->) where
   (+++) = (A.+++)
 
-instance Associative (->) (:+) where
-#ifdef AssociativeDefaultCartesian
-  lassoc (Left a) = Left (Left a)
-  lassoc (Right (Left b)) = Left (Right b)
-  lassoc (Right (Right c)) = Right c
-  rassoc (Left (Left a)) = Left a
-  rassoc (Left (Right b)) = Right (Left b)
-  rassoc (Right c) = Right (Right c)
-#endif
-
-instance Symmetric (->) (:+) where
-#ifdef SymmetricDefaultCartesian
-  swap (Left a) = Right a
-  swap (Right b) = Left b
-#endif
-
-instance Cocartesian (->) (:+) where
+instance Cocartesian (:+) (->) where
   inl = P.Left
   inr = P.Right
   jam = id A.||| id
   -- Equivalently,
   -- jam (Left  a) = a
   -- jam (Right a) = a
+  -- Also, could use `either` or `bimap` instead of `A.|||`
+
+deriving via (ViaCartesian   (:*) (->)) instance Associative (:*) (->)
+deriving via (ViaCartesian   (:*) (->)) instance Symmetric   (:*) (->)
+deriving via (ViaCocartesian (:+) (->)) instance Associative (:+) (->)
+deriving via (ViaCocartesian (:+) (->)) instance Symmetric   (:+) (->)
 
 newtype Ap f a = Ap { unAp :: f a }
   deriving (Functor, Generic, Generic1)
@@ -345,18 +330,18 @@ instance Representable f => Representable (Ap f) where
   tabulate = Ap . tabulate
   index = index . unAp
 
-instance Representable r => MonoidalR (->) r Ap where
+instance Representable r => MonoidalR r Ap (->) where
   cross rab (Ap ra) = Ap (liftR2 ($) rab ra)
 
-instance Representable r => CartesianR (->) r Ap where
+instance Representable r => CartesianR r Ap (->) where
   exs = tabulate (flip index)
   dups = pureRep
 
 data RepAnd r x = RepAnd (Rep r) x
 
-instance Representable r => ComonoidalR (->) r RepAnd where
+instance Representable r => ComonoidalR r RepAnd (->) where
   plus fs (RepAnd i a) = RepAnd i ((fs `index` i) a)
 
-instance Representable r => CocartesianR (->) r RepAnd where
+instance Representable r => CocartesianR r RepAnd (->) where
   ins = tabulate RepAnd
   jams (RepAnd _ a) = a

--- a/src/Category/Constraint.hs
+++ b/src/Category/Constraint.hs
@@ -11,7 +11,6 @@ import Data.Constraint
 import Category
 
 instance Category (:-) where
-  type Obj' (:-) = Unconstrained
   id  = refl
   (.) = trans
 
@@ -19,17 +18,17 @@ instance Category (:-) where
 class    (p,q) => p && q
 instance (p,q) => p && q
 
-instance Monoidal (:-) (&&) where
+instance Monoidal (&&) (:-) where
   p *** q = Sub (Dict \\ p \\ q)
 
-instance Associative (:-) (&&) where
+instance Associative (&&) (:-) where
   lassoc = Sub Dict
   rassoc = Sub Dict
 
-instance Symmetric (:-) (&&) where
+instance Symmetric (&&) (:-) where
   swap = Sub Dict
 
-instance Cartesian (:-) (&&) where
+instance Cartesian (&&) (:-) where
   exl = Sub Dict
   exr = Sub Dict
   dup = Sub Dict

--- a/src/Category/Index.hs
+++ b/src/Category/Index.hs
@@ -46,30 +46,30 @@ instance Category k => Category (Indexed k) where
 
 -- The logarithm of a product is the sum of the logarithms.
 
-instance Monoidal k (:*:) => Monoidal (Indexed k) (:+) where
+instance Monoidal (:*:) k => Monoidal (:+) (Indexed k) where
   Indexed f *** Indexed g = Indexed (f *** g)
 
-instance Associative k (:*:) => Associative (Indexed k) (:+) where
+instance Associative (:*:) k => Associative (:+) (Indexed k) where
   lassoc = Indexed lassoc
   rassoc = Indexed rassoc
 
-instance Symmetric k (:*:) => Symmetric (Indexed k) (:+) where
+instance Symmetric (:*:) k => Symmetric (:+) (Indexed k) where
   swap = Indexed swap
 
-instance Cartesian k (:*:) => Cartesian (Indexed k) (:+) where
+instance Cartesian (:*:) k => Cartesian (:+) (Indexed k) where
   exl = Indexed exl
   exr = Indexed exr
   dup = Indexed dup
 
-instance Comonoidal k (:*:) => Comonoidal (Indexed k) (:+) where
+instance Comonoidal (:*:) k => Comonoidal (:+) (Indexed k) where
   Indexed f +++ Indexed g = Indexed (f +++ g)
 
-instance Cocartesian k (:*:) => Cocartesian (Indexed k) (:+) where
+instance Cocartesian (:*:) k => Cocartesian (:+) (Indexed k) where
   inl = Indexed inl
   inr = Indexed inr
   jam = Indexed jam
 
-instance Biproduct k (:*:) => Biproduct (Indexed k) (:+)
+instance Biproduct (:*:) k => Biproduct (:+) (Indexed k)
 
 -- TODO: generalize from (:*:) and (:+).
 
@@ -77,7 +77,7 @@ instance Biproduct k (:*:) => Biproduct (Indexed k) (:+)
 
 type RepX r i = Rep r :* i
 
-instance MonoidalR k r (:.:) => MonoidalR (Indexed k) r RepX where
+instance MonoidalR r (:.:) k => MonoidalR r RepX (Indexed k) where
   cross (fmap unIndexed -> fs) = Indexed (cross fs)
 
 -- Hm. Needs unsaturated type synonym. We could make RepX a data type or

--- a/src/Category/Isomorphism.hs
+++ b/src/Category/Isomorphism.hs
@@ -43,17 +43,17 @@ instance Category k => Category (Iso k) where
   id = id :<-> id
   (g :<-> g') . (f :<-> f') = (g . f) :<-> (f' . g')
 
-instance Associative k p => Associative (Iso k) p where
+instance Associative p k => Associative p (Iso k) where
   lassoc = lassoc :<-> rassoc
   rassoc = rassoc :<-> lassoc
 
-instance Symmetric k p => Symmetric (Iso k) p where
+instance Symmetric p k => Symmetric p (Iso k) where
   swap = swap :<-> swap
 
 -- We cannot use the default definitions for Associative and Symmetric, because
 -- Iso k is not cartesian.
 
-instance Monoidal k p => Monoidal (Iso k) p where
+instance Monoidal p k => Monoidal p (Iso k) where
   (f :<-> f') *** (g :<-> g') = (f *** g) :<-> (f' *** g')
 
 -- Illegal instance declaration for ‘Monoidal (Iso k) p’
@@ -65,7 +65,7 @@ instance Monoidal k p => Monoidal (Iso k) p where
 --
 -- TODO: revisit after monkeying with the Monoidal class.
 
-instance Comonoidal k co => Comonoidal (Iso k) co where
+instance Comonoidal co k => Comonoidal co (Iso k) where
   (f :<-> f') +++ (g :<-> g') = (f +++ g) :<-> (f' +++ g')
 
 #if 0
@@ -84,18 +84,18 @@ instance UnitCat k => UnitCat (Iso k) where
 via :: (Category k, Obj2 k a b) => Iso k b b -> Iso k a b -> Iso k a a
 (g :<-> g') `via` (ab :<-> ba) = ba . g . ab :<-> ba . g' . ab
 
-join2Iso :: (Cocartesian k co, Obj3 k a c d) 
+join2Iso :: (Cocartesian co k, Obj3 k a c d)
          => (c `k` a) :* (d `k` a) <-> ((c `co` d) `k` a)
 join2Iso = join2 :<-> unjoin2
 
-fork2Iso :: (Cartesian k p, Obj3 k a c d)
+fork2Iso :: (Cartesian p k, Obj3 k a c d)
          => (a `k` c) :* (a `k` d) <-> (a `k` (c `p` d))
 fork2Iso = fork2 :<-> unfork2
 
-joinIso :: (CocartesianR k r co, Obj2 k a b) => r (a `k` b) <-> co r a `k` b
+joinIso :: (CocartesianR r co k, Obj2 k a b) => r (a `k` b) <-> co r a `k` b
 joinIso = join :<-> unjoin
 
-forkIso :: (CartesianR k r p, Obj2 k a b) => r (a `k` b) <-> (a `k` p r b)
+forkIso :: (CartesianR r p k, Obj2 k a b) => r (a `k` b) <-> (a `k` p r b)
 forkIso = fork :<-> unfork
 
 curryIso :: ((a :* b) -> c) <-> (a -> (b -> c))
@@ -127,7 +127,7 @@ fmapIso fg h = isoFwd fg . fmap h . isoRev fg
 
 -- Don't pattern match fg, since we need two type instantiations.
 -- For instance, the following doesn't type-check:
--- 
+--
 --   fmapIso (fg :<-> gf) h = fg . fmap h . gf
 
 -- Is this fmapIso really the most useful and natural variant?

--- a/src/Category/Opposite.hs
+++ b/src/Category/Opposite.hs
@@ -17,44 +17,44 @@ instance Category k => Category (Op k) where
   id = Op id
   Op g . Op f = Op (f . g)
 
-instance Comonoidal k co => Monoidal (Op k) co where
+instance Comonoidal co k => Monoidal co (Op k) where
   Op f *** Op g = Op (f +++ g)
 
-instance Associative k p => Associative (Op k) p where
+instance Associative p k => Associative p (Op k) where
   lassoc = Op rassoc
   rassoc = Op lassoc
 
-instance Symmetric k p => Symmetric (Op k) p where
+instance Symmetric p k => Symmetric p (Op k) where
   swap = Op swap
 
-instance Cocartesian k co => Cartesian (Op k) co where
+instance Cocartesian co k => Cartesian co (Op k) where
   exl = Op inl
   exr = Op inr
   dup = Op jam
 
-instance Monoidal k p => Comonoidal (Op k) p where
+instance Monoidal p k => Comonoidal p (Op k) where
   Op f +++ Op g = Op (f *** g)
 
-instance Cartesian k p => Cocartesian (Op k) p where
+instance Cartesian p k => Cocartesian p (Op k) where
   inl = Op exl
   inr = Op exr
   jam = Op dup
 
-instance ComonoidalR k r p => MonoidalR (Op k) r p where
+instance ComonoidalR r p k => MonoidalR r p (Op k) where
   cross (fmap unOp -> fs) = Op (plus fs)
 
-instance MonoidalR k r p => ComonoidalR (Op k) r p where
+instance MonoidalR r p k => ComonoidalR r p (Op k) where
   plus (fmap unOp -> fs) = Op (cross fs)
 
-instance CocartesianR k r p => CartesianR (Op k) r p where
+instance CocartesianR r p k => CartesianR r p (Op k) where
   exs  = Op <$> ins
   dups = Op jams
 
-instance CartesianR k r p => CocartesianR (Op k) r p where
+instance CartesianR r p k => CocartesianR r p (Op k) where
   ins  = Op <$> exs
   jams = Op dups
 
-instance BiproductR k r p => BiproductR (Op k) r p
+instance BiproductR r p k => BiproductR r p (Op k)
 
 
 -- Illegal instance declaration for ‘Monoidal (Op k) co’

--- a/src/Category/Semiring.hs
+++ b/src/Category/Semiring.hs
@@ -9,12 +9,11 @@ import Category
 newtype SemiringCat s a b = S s
 
 instance Semiring s => Category (SemiringCat s) where
-  type Obj' (SemiringCat s) = Unconstrained
   id = S one
   S t . S s = S (t * s)
 
 deriving instance Additive s => Additive (SemiringCat s a b)
 
 -- Do we want a Semiring instance?
--- 
+--
 -- deriving instance Semiring s => Semiring (SemiringCat s a b)

--- a/src/LinearFunction.hs
+++ b/src/LinearFunction.hs
@@ -19,28 +19,28 @@ import Category.Isomorphism
 newtype L (s :: *) a b = L { unF :: a s -> b s }
 
 instance Category (L s) where
-  type Obj' (L s) = Representable 
+  type Obj' (L s) = Representable
   id = L id
   L g . L f = L (g . f)
 
-instance Monoidal (L s) (:*:) where
+instance Monoidal (:*:) (L s) where
   L f *** L g = L (\ (a :*: b) -> f a :*: g b)
 
-instance Cartesian (L s) (:*:) where
+instance Cartesian (:*:) (L s) where
   exl = L exlF
   exr = L exrF
   dup = L dupF
 
-instance Comonoidal (L s) (:*:) where (+++) = (***)
+instance Comonoidal (:*:) (L s) where (+++) = (***)
 
-instance Additive s => Cocartesian (L s) (:*:) where
+instance Additive s => Cocartesian (:*:) (L s) where
   inl = L (:*: zeroV)
   inr = L (zeroV :*:)
   jam = L (uncurryF (+^))
 
-instance Additive s => Biproduct (L s) (:*:)
+instance Additive s => Biproduct (:*:) (L s)
 
-instance Representable r => MonoidalR (L s) r (:.:) where
+instance Representable r => MonoidalR r (:.:) (L s) where
   cross :: Obj2 (L s) a b => r (L s a b) -> L s (r :.: a) (r :.: b)
   cross fs = L (Comp1 . liftR2 unF fs . unComp1)
 
@@ -52,17 +52,17 @@ Comp1 . liftR2 unF fs . unComp1 :: (r :.: a) s -> (r :.: b) s
 cross = L . inNew (liftR2 unF)
 #endif
 
-instance Representable r => CartesianR (L s) r (:.:) where
+instance Representable r => CartesianR r (:.:) (L s) where
   exs :: Obj (L s) a => r (L s (r :.: a) a)
   exs = tabulate (\ i -> L (\ (Comp1 as) -> as `index` i))
   dups :: Obj (L s) a => L s a (r :.: a)
   dups = L (Comp1 . pureRep)
 
-instance Representable r => ComonoidalR (L s) r (:.:) where
+instance Representable r => ComonoidalR r (:.:) (L s) where
   plus = cross
 
 instance (Additive s, Representable r, Eq (Rep r), Foldable r)
-      => CocartesianR (L s) r (:.:) where
+      => CocartesianR r (:.:) (L s) where
   ins :: Obj (L s) a => r (L s a (r :.: a))
   ins = tabulate (L . oneHot)
         -- tabulate $ \ i -> L (oneHot i)


### PR DESCRIPTION
Following the example of [this comment](https://github.com/conal/linalg/pull/41#discussion_r467925230), I swapped the order of type arguments `p` and `k` (or `co` and `k`) to make automatic instance derivations possible.  Then, I removed the cpp for default implementations in `Associative` and `Symmetric` and added `ViaCartesian` and `ViaCocartesian` newtypes.  These new types can be used with `DerivingVia` to derive instances of `Associative` and `Symmetric` just as if default implementations existed.