### PR TITLE
Add custom CatPrelude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 linalg.cabal
+.stack*
+stack.yaml.lock

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ default-extensions:
   - InstanceSigs
   # - LambdaCase
   - MultiParamTypeClasses
+  - NoImplicitPrelude
   - PatternSynonyms
   - QuantifiedConstraints
   - RankNTypes
@@ -57,3 +58,4 @@ library:
     - LinearFunction
     - InductiveMatrix # coming
     - LinAlg          # going
+    - CatPrelude

--- a/src/CatPrelude.hs
+++ b/src/CatPrelude.hs
@@ -1,0 +1,21 @@
+-- | Custom Category-Prelude
+
+module CatPrelude (
+    module Prelude
+  , module Misc
+  , module Category
+  , module Data.Distributive
+  , module Data.Functor.Rep
+  , module GHC.Generics
+  , module GHC.Types
+  ) where
+
+import Prelude hiding (id, sum, unzip, (*), (+), (.))
+
+import Misc
+import Category
+
+import Data.Distributive
+import Data.Functor.Rep
+import GHC.Generics ((:*:)(..), (:+:)(..), (:.:)(..), Generic, Generic1, Par1(..), U1(..))
+import GHC.Types (Constraint)

--- a/src/InductiveMatrix.hs
+++ b/src/InductiveMatrix.hs
@@ -9,13 +9,8 @@ and José N Oliveira (Haskell Symposium 2020) [URL?]. The main differences:
 
 module InductiveMatrix where
 
-import Prelude hiding ((+),sum,(*),unzip)
+import CatPrelude
 
-import GHC.Generics (Par1(..), (:*:)(..), (:.:)(..))
-import Data.Functor.Rep
-
-import Misc
-import Category
 import LinearFunction hiding (L)
 
 -------------------------------------------------------------------------------

--- a/src/LinearFunction.hs
+++ b/src/LinearFunction.hs
@@ -6,13 +6,7 @@
 
 module LinearFunction where
 
-import Prelude hiding (id,(.),(+),(*),sum)
-
-import GHC.Generics (Par1(..),(:*:)(..),(:.:)(..))
-import Data.Functor.Rep
-
-import Misc
-import Category
+import CatPrelude
 
 -- | Linear functions
 newtype L (s :: *) a b = L { unF :: a s -> b s }


### PR DESCRIPTION
As mentioned in [a comment of mine](https://github.com/conal/linalg/pull/28#pullrequestreview-460333676), we can make our own custom prelude so that our imports are a little cleaner.  This PR does this.

For now, I kept it rather simple.  This new `CatPrelude` is basically just the regular `Prelude` with a few modifications:
- `(+)`, `sum`, `(*)`, `unzip`, `id`, and `(.)` are not exported.
- The contents of `Misc` and `Category` are exported.
- The contents of `Data.Distributive` and `Data.Functor.Rep` are exported.
- The pieces of `GHC.Generics` and `GHC.Types` (just `Constraint` in this case) that we use are exported.

Depending on where this repo goes, we could consider more aggressive changes:
- Rely on something like [protolude](https://hackage.haskell.org/package/protolude) instead of GHC's Prelude, which is a modified prelude that, among many nice features, does not include partial functions by default.
- Add more "default" modules, for instance, `Dict` (and related helpers) from `Data.Constraint`.

Note that I specifically didn't force `LinAlg` to use `CatPrelude` because it is not set up for using our `Category` module yet.  I expect that future modules we write (including the category-rewrite of `LinAlg`) will all start with `import CatPrelude`.