### PR TITLE
vector/map isomorphisms

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ library:
   exposed-modules:
     - Misc
     - Category
+    - Orphans
     - LinearFunction
     - InductiveMatrix # coming
     - LinAlg          # going

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -12,15 +12,12 @@ module Category where
 import qualified Prelude as P
 import Prelude hiding (id,(.))
 import GHC.Types (Constraint)
-import GHC.Generics (Generic,Generic1)
 import qualified Control.Arrow as A
-import Data.Distributive
+import Data.Monoid (Ap(..))
 import Data.Functor.Rep
 
 import Misc
-
-class    Unconstrained a
-instance Unconstrained a
+import Orphans ()
 
 -- https://github.com/conal/linalg/pull/28#issuecomment-670313952
 class    Obj' k a => Obj k a
@@ -315,20 +312,6 @@ deriving via (ViaCartesian   (:*) (->)) instance Associative (:*) (->)
 deriving via (ViaCartesian   (:*) (->)) instance Symmetric   (:*) (->)
 deriving via (ViaCocartesian (:+) (->)) instance Associative (:+) (->)
 deriving via (ViaCocartesian (:+) (->)) instance Symmetric   (:+) (->)
-
-newtype Ap f a = Ap { unAp :: f a }
-  deriving (Functor, Generic, Generic1)
-
--- TODO: switch to Data.Monoid.Ap if/when it gets Distributive and Representable
--- instances.
-
-instance Distributive f => Distributive (Ap f) where
-  distribute = Ap . distribute . fmap unAp
-
-instance Representable f => Representable (Ap f) where
-  type Rep (Ap f) = Rep f
-  tabulate = Ap . tabulate
-  index = index . unAp
 
 instance Representable r => MonoidalR r Ap (->) where
   cross rab (Ap ra) = Ap (liftR2 ($) rab ra)

--- a/src/LinearFunction.hs
+++ b/src/LinearFunction.hs
@@ -205,8 +205,8 @@ unscale = unPar1 . toScalar'
 -- | Some "products", defined in terms of composition
 -------------------------------------------------------------------------------
 
-inner :: (Representable a, Foldable a, Semiring s) => a s -> a s -> s
-inner b a = unscale (toScalar b . fromScalar a)
+inner :: (Representable a, Foldable a, Semiring s) => a s -> a s -> L s Par1 Par1
+inner b a = toScalar b . fromScalar a
 
 outer :: (Representable a, Foldable a, Representable b, Semiring s)
       => b s -> a s -> L s a b

--- a/src/LinearFunction.hs
+++ b/src/LinearFunction.hs
@@ -206,9 +206,9 @@ unscale = unPar1 . toScalar'
 -------------------------------------------------------------------------------
 
 inner :: (Representable a, Foldable a, Semiring s) => a s -> a s -> L s Par1 Par1
-inner b a = toScalar b . fromScalar a
+b `inner` a = toScalar b . fromScalar a
 
 outer :: (Representable a, Foldable a, Representable b, Semiring s)
       => b s -> a s -> L s a b
-outer b a = fromScalar b . toScalar a
+b `outer` a = fromScalar b . toScalar a
 

--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -7,7 +7,7 @@ module Misc where
 import qualified Prelude as P
 import Prelude hiding ((+),sum,(*),unzip)
 import GHC.Types (Constraint)
-import GHC.Generics ((:*:)(..))
+import GHC.Generics ((:*:)(..),(:+:)(..))
 import Control.Newtype.Generics
 
 import Data.Functor.Rep
@@ -107,6 +107,16 @@ exrF (_ :*: b) = b
 dupF :: a --> a :*: a
 dupF a = a :*: a
 
+inlF :: a --> a :+: b
+inlF a = L1 a
+
+inrF :: b --> a :+: b
+inrF a = R1 a
+
+eitherF :: (a t -> c) -> (b t -> c) -> ((a :+: b) t -> c)
+eitherF f _ (L1 a) = f a
+eitherF _ g (R1 b) = g b
+
 curryF :: ((a :*: b) s -> c s) -> (a s -> b s -> c s)
 curryF f a b = f (a :*: b)
 
@@ -173,3 +183,6 @@ infixr 1 ~>
 {-# INLINE (<~) #-}
 
 -- TODO: Maybe move (<~) and (~>) to Category and generalize from (->)to any category.
+
+class    Unconstrained a
+instance Unconstrained a

--- a/src/Orphans.hs
+++ b/src/Orphans.hs
@@ -1,0 +1,51 @@
+{-# OPTIONS_GHC -Wall -fno-warn-orphans #-}
+
+-- | Orphan instances
+
+module Orphans where
+
+import Prelude
+
+import GHC.Generics (Par1(..),(:+:)(..),(:*:)(..),(:.:)(..))
+import Data.Monoid (Ap(..))
+import Data.Distributive (Distributive(..))
+import Data.Functor.Rep (Representable(..))
+import Control.Newtype.Generics
+
+import Misc
+
+-------------------------------------------------------------------------------
+-- | Newtype
+-------------------------------------------------------------------------------
+
+instance Newtype (Par1 t) where
+  type O (Par1 t) = t
+  pack = Par1
+  unpack = unPar1
+
+instance Newtype ((a :*: b) t) where
+  type O ((a :*: b) t) = a t :* b t
+  pack (a,b) = a :*: b
+  unpack (a :*: b) = (a,b)
+
+instance Newtype ((a :+: b) t) where
+  type O ((a :+: b) t) = a t :+ b t
+  pack = either L1 R1
+  unpack = eitherF Left Right
+
+instance Newtype ((a :.: b) t) where
+  type O ((a :.: b) t) = a (b t)
+  pack = Comp1
+  unpack = unComp1
+
+-------------------------------------------------------------------------------
+-- | Ap
+-------------------------------------------------------------------------------
+
+instance Distributive f => Distributive (Ap f) where
+  distribute = Ap . distribute . fmap getAp
+
+instance Representable f => Representable (Ap f) where
+  type Rep (Ap f) = Rep f
+  tabulate = Ap . tabulate
+  index = index . getAp


### PR DESCRIPTION
- `Orphans` module with `Ap` and `Newtype` instances.
- Move `Unconstrained` from `Category` to `Misc`.
- `(:+:)` utilities in `Misc`
- Vector/map isomorphisms in `LinearFunction`, use for inner and outer products