### PR TITLE
Make the `Obj'` type family depend on object as well as category.

### DIFF
--- a/src/Category.hs
+++ b/src/Category.hs
@@ -32,8 +32,8 @@ instance Obj' k a => Obj k a
 -- Use UndecidableSuperClasses to accept this
 
 class Category (k :: u -> u -> *) where
-  type Obj' k :: u -> Constraint
-  type instance Obj' k = Unconstrained
+  type Obj' k (a :: u) :: Constraint
+  type instance Obj' k u = ()
   infixr 9 .
   id :: Obj k a => a `k` a
   (.) :: Obj3 k a b c => (b `k` c) -> (a `k` b) -> (a `k` c)
@@ -197,7 +197,7 @@ class Bicartesian p p k => Biproduct p k
 -- `Associative` and `Symmetric` instances using the `Cartesian` operations.
 newtype ViaCartesian p k a b = ViaCartesian (k a b)
 instance Category k => Category (ViaCartesian p k) where
-  type Obj' (ViaCartesian p k) = Obj k
+  type Obj' (ViaCartesian p k) a = Obj k a
   id = ViaCartesian id
   ViaCartesian g . ViaCartesian f = ViaCartesian (g . f)
 deriving instance Monoidal  p k => Monoidal  p (ViaCartesian p k)
@@ -213,7 +213,7 @@ instance Cartesian p k => Symmetric p (ViaCartesian p k) where
 -- `Associative` and `Symmetric` instances using the `Cocartesian` operations.
 newtype ViaCocartesian co k a b = ViaCocartesian (k a b)
 instance Category k => Category (ViaCocartesian p k) where
-  type Obj' (ViaCocartesian p k) = Obj k
+  type Obj' (ViaCocartesian p k) a = Obj k a
   id = ViaCocartesian id
   ViaCocartesian g . ViaCocartesian f = ViaCocartesian (g . f)
 deriving instance Comonoidal  co k => Comonoidal  co (ViaCocartesian co k)

--- a/src/Category/Indexed.hs
+++ b/src/Category/Indexed.hs
@@ -34,7 +34,7 @@ instance Obj k (Trie i) => ObjI k i
 -- (Use UndecidableInstances to permit this)
 
 instance Category k => Category (Indexed k) where
-  type Obj' (Indexed k) = ObjI k
+  type Obj' (Indexed k) a = ObjI k a
   id = Indexed id
   Indexed g . Indexed f = Indexed (g . f)
 

--- a/src/Category/Isomorphism.hs
+++ b/src/Category/Isomorphism.hs
@@ -36,7 +36,7 @@ type (<->) = Iso (->)
 -------------------------------------------------------------------------------
 
 instance Category k => Category (Iso k) where
-  type Obj' (Iso k) = Obj k
+  type Obj' (Iso k) a = Obj k a
   id = id :<-> id
   (g :<-> g') . (f :<-> f') = (g . f) :<-> (f' . g')
 

--- a/src/Category/Opposite.hs
+++ b/src/Category/Opposite.hs
@@ -11,7 +11,7 @@ import CatPrelude
 newtype Op k a b = Op { unOp :: b `k` a }
 
 instance Category k => Category (Op k) where
-  type Obj' (Op k) = Obj k
+  type Obj' (Op k) a = Obj k a
   id = Op id
   Op g . Op f = Op (f . g)
 

--- a/src/InductiveMatrix.hs
+++ b/src/InductiveMatrix.hs
@@ -64,6 +64,6 @@ instance LinearMap L where
 -------------------------------------------------------------------------------
 
 instance Category (L s) where
-  type Obj' (L s) = V
+  type Obj' (L s) a = V a
   id = undefined
   (.) = undefined

--- a/src/LinearFunction.hs
+++ b/src/LinearFunction.hs
@@ -13,7 +13,7 @@ import Category.Isomorphism
 newtype L (s :: *) a b = L { unL :: a s -> b s }
 
 instance Category (L s) where
-  type Obj' (L s) = Representable
+  type Obj' (L s) a = Representable a
   id = L id
   L g . L f = L (g . f)
 

--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -183,6 +183,3 @@ infixr 1 ~>
 {-# INLINE (<~) #-}
 
 -- TODO: Maybe move (<~) and (~>) to Category and generalize from (->)to any category.
-
-class    Unconstrained a
-instance Unconstrained a


### PR DESCRIPTION
The `Category` class in section 6 of [*Type Your Matrices*](https://github.com/bolt12/tymfgg-pearl) uses an associated constraint that depends on the object as well as the category. Mine depended only on the category and so sometimes necessitates defining new classes. I carried over this choice from concat, but I guess the motivation has gone away with the introduction of quantified constraints or some other change. (Now I wonder if concat even needs it. In either case, I should probably switch concat over to quantified constraints as well and eliminate all of the constraint entailment programming.) I suspect it helps considerably that we define an [extra class that wraps the associated `Obj'` constraint](https://github.com/conal/linalg/pull/28#issuecomment-670313952).

This change eliminated the need for `Unconstrained`, so I dropped it.
