### PR TITLE
Unify Comonoidal with Monoidal

### DIFF
--- a/src/Category.hs
+++ b/src/Category.hs
@@ -55,7 +55,7 @@ type Obj6 k a b c d e f = C6 (Obj k) a b c d e f
 -- Seee https://github.com/conal/linalg/pull/28#issuecomment-670313952
 type ObjBin p k = ((forall a b. Obj2 k a b => Obj k (a `p` b)) :: Constraint)
 
-class (Category k, ObjBin p k) => Monoidal p k | k -> p where
+class (Category k, ObjBin p k) => Monoidal p k {- | k -> p -} where
   infixr 3 ***
   (***) :: Obj4 k a b c d => (a `k` c) -> (b `k` d) -> ((a `p` b) `k` (c `p` d))
 
@@ -141,7 +141,7 @@ class Symmetric p k where
 -- <https://hackage.haskell.org/package/categories/docs/Control-Category-Monoidal.html>.
 
 
-class (Category k, ObjBin co k) => Comonoidal co k | k -> co where
+class (Category k, ObjBin co k) => Comonoidal co k {- | k -> co -} where
   infixr 2 +++
   (+++) :: Obj4 k a b c d => (a `k` c) -> (b `k` d) -> ((a `co` b) `k` (c `co` d))
 
@@ -193,7 +193,7 @@ type Bicartesian p co k = (Cartesian p k, Cocartesian co k)
 class Bicartesian p p k => Biproduct p k
 
 
-class (Category k, ObjBin e k) => Closed e k | k -> e where
+class (Category k, ObjBin e k) => Closed e k {- | k -> e -} where
   (^^^) :: Obj4 k a b c d => (a `k` b) -> (d `k` c) -> ((c `e` a) `k` (d `e` b))
 
 dom :: (Closed e k, Obj3 k c a d) => (d `k` c) -> ((c `e` a) `k` (d `e` a))

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -53,7 +53,7 @@ type Obj6 k a b c d e f = C6 (Obj k) a b c d e f
 -- Seee https://github.com/conal/linalg/pull/28#issuecomment-670313952
 type ObjBin p k = ((forall a b. Obj2 k a b => Obj k (a `p` b)) :: Constraint)
 
-class (Category k, ObjBin p k) => Monoidal p k {- | k -> p -} where
+class (Category k, ObjBin p k) => Monoidal p k where
   infixr 3 ###
   (###) :: Obj4 k a b c d => (a `k` c) -> (b `k` d) -> ((a `p` b) `k` (c `p` d))
 
@@ -171,7 +171,7 @@ type Bicartesian p co k = (Cartesian p k, Cocartesian co k)
 class Bicartesian p p k => Biproduct p k
 
 
-class (Category k, ObjBin e k) => Closed e k {- | k -> e -} where
+class (Category k, ObjBin e k) => Closed e k where
   (^^^) :: Obj4 k a b c d => (a `k` b) -> (d `k` c) -> ((c `e` a) `k` (d `e` b))
 
 dom :: (Closed e k, Obj3 k c a d) => (d `k` c) -> ((c `e` a) `k` (d `e` a))
@@ -235,7 +235,7 @@ type ObjR' r p k = ((forall z. Obj k z => Obj k (p r z)) :: Constraint)
 class    (Functor r, ObjR' r p k) => ObjR r p k
 instance (Functor r, ObjR' r p k) => ObjR r p k
 
-class (Category k, ObjR r p k) => MonoidalR r p k {- | k r -> p -} where
+class (Category k, ObjR r p k) => MonoidalR r p k where
   bifunctor :: Obj2 k a b => r (a `k` b) -> (p r a `k` p r b)
 
 class MonoidalR r p k => CartesianR r p k where
@@ -249,9 +249,6 @@ unfork :: (CartesianR r p k, Obj2 k a b) => a `k` (p r b) -> r (a `k` b)
 unfork f = (. f) <$> exs
 
 -- Exercise: Prove that fork and unfork form an isomorphism.
-
--- class (Category k, ObjR r co k) => MonoidalR r co k | k r -> co where
---   plus :: Obj2 k a b => r (a `k` b) -> (co r a `k` co r b)
 
 -- N-ary biproducts
 class MonoidalR r co k => CocartesianR r co k where

--- a/src/Category/Constraint.hs
+++ b/src/Category/Constraint.hs
@@ -24,7 +24,7 @@ instance (p,q) => p && q
 -- Use UndecidableSuperClasses to accept this
 
 instance Monoidal (&&) (:-) where
-  p *** q = Sub (Dict \\ p \\ q)
+  p ### q = Sub (Dict \\ p \\ q)
 
 instance Associative (&&) (:-) where
   lassoc = Sub Dict

--- a/src/Category/Indexed.hs
+++ b/src/Category/Indexed.hs
@@ -1,6 +1,7 @@
--- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
 {-# LANGUAGE UndecidableSuperClasses #-} -- see below
 {-# LANGUAGE UndecidableInstances #-} -- see below
+
+-- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
 
 -- | Logarithms (Representable indices) as objects
 
@@ -41,7 +42,7 @@ instance Category k => Category (Indexed k) where
 -- The logarithm of a product is the sum of the logarithms.
 
 instance Monoidal (:*:) k => Monoidal (:+) (Indexed k) where
-  Indexed f *** Indexed g = Indexed (f *** g)
+  Indexed f ### Indexed g = Indexed (f ### g)
 
 instance Associative (:*:) k => Associative (:+) (Indexed k) where
   lassoc = Indexed lassoc
@@ -54,9 +55,6 @@ instance Cartesian (:*:) k => Cartesian (:+) (Indexed k) where
   exl = Indexed exl
   exr = Indexed exr
   dup = Indexed dup
-
-instance Comonoidal (:*:) k => Comonoidal (:+) (Indexed k) where
-  Indexed f +++ Indexed g = Indexed (f +++ g)
 
 instance Cocartesian (:*:) k => Cocartesian (:+) (Indexed k) where
   inl = Indexed inl

--- a/src/Category/Isomorphism.hs
+++ b/src/Category/Isomorphism.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-} -- see below
-
 -- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
 
 -- | Isomorphisms
@@ -51,19 +49,7 @@ instance Symmetric p k => Symmetric p (Iso k) where
 -- Iso k is not cartesian.
 
 instance Monoidal p k => Monoidal p (Iso k) where
-  (f :<-> f') *** (g :<-> g') = (f *** g) :<-> (f' *** g')
-
--- Illegal instance declaration for ‘Monoidal (Iso k) p’
---   The coverage condition fails in class ‘Monoidal’
---     for functional dependency: ‘k -> p’
---   Reason: lhs type ‘Iso k’ does not determine rhs type ‘p’
---   Un-determined variable: p
---   Using UndecidableInstances might help
---
--- TODO: revisit after monkeying with the Monoidal class.
-
-instance Comonoidal co k => Comonoidal co (Iso k) where
-  (f :<-> f') +++ (g :<-> g') = (f +++ g) :<-> (f' +++ g')
+  (f :<-> f') ### (g :<-> g') = (f ### g) :<-> (f' ### g')
 
 #if 0
 instance UnitCat k => UnitCat (Iso k) where

--- a/src/Category/Opposite.hs
+++ b/src/Category/Opposite.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-} -- see below
-
 -- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
 
 -- | Opposite category
@@ -15,8 +13,8 @@ instance Category k => Category (Op k) where
   id = Op id
   Op g . Op f = Op (f . g)
 
-instance Comonoidal co k => Monoidal co (Op k) where
-  Op f *** Op g = Op (f +++ g)
+instance Monoidal co k => Monoidal co (Op k) where
+  Op f ### Op g = Op (f ### g)
 
 instance Associative p k => Associative p (Op k) where
   lassoc = Op rassoc
@@ -30,9 +28,6 @@ instance Cocartesian co k => Cartesian co (Op k) where
   exr = Op inr
   dup = Op jam
 
-instance Monoidal p k => Comonoidal p (Op k) where
-  Op f +++ Op g = Op (f *** g)
-
 instance Cartesian p k => Cocartesian p (Op k) where
   inl = Op exl
   inr = Op exr
@@ -43,11 +38,8 @@ instance Biproduct p k => Biproduct p (Op k)
 instance Closed e k => Closed e (Op k) where
   Op f ^^^ Op g = Op (f ^^^ g)
 
-instance ComonoidalR r p k => MonoidalR r p (Op k) where
-  cross (fmap unOp -> fs) = Op (plus fs)
-
-instance MonoidalR r p k => ComonoidalR r p (Op k) where
-  plus (fmap unOp -> fs) = Op (cross fs)
+instance MonoidalR r p k => MonoidalR r p (Op k) where
+  bifunctor (fmap unOp -> fs) = Op (bifunctor fs)
 
 instance CocartesianR r p k => CartesianR r p (Op k) where
   exs  = Op <$> ins
@@ -58,10 +50,3 @@ instance CartesianR r p k => CocartesianR r p (Op k) where
   jams = Op dups
 
 instance BiproductR r p k => BiproductR r p (Op k)
-
-
--- Illegal instance declaration for ‘Monoidal (Op k) co’
---   The coverage condition fails in class ‘Monoidal’
---     for functional dependency: ‘k -> p’
---   Reason: lhs type ‘Op k’ does not determine rhs type ‘co’
---   Un-determined variable: co

--- a/src/Category/Opposite.hs
+++ b/src/Category/Opposite.hs
@@ -39,7 +39,7 @@ instance Closed e k => Closed e (Op k) where
   Op f ^^^ Op g = Op (f ^^^ g)
 
 instance MonoidalR r p k => MonoidalR r p (Op k) where
-  bifunctor (fmap unOp -> fs) = Op (bifunctor fs)
+  rmap (fmap unOp -> fs) = Op (rmap fs)
 
 instance CocartesianR r p k => CartesianR r p (Op k) where
   exs  = Op <$> ins

--- a/src/LinearFunction.hs
+++ b/src/LinearFunction.hs
@@ -18,14 +18,12 @@ instance Category (L s) where
   L g . L f = L (g . f)
 
 instance Monoidal (:*:) (L s) where
-  L f *** L g = L (\ (a :*: b) -> f a :*: g b)
+  L f ### L g = L (\ (a :*: b) -> f a :*: g b)
 
 instance Cartesian (:*:) (L s) where
   exl = L exlF
   exr = L exrF
   dup = L dupF
-
-instance Comonoidal (:*:) (L s) where (+++) = (***)
 
 instance Additive s => Cocartesian (:*:) (L s) where
   inl = L (:*: zeroV)
@@ -35,15 +33,15 @@ instance Additive s => Cocartesian (:*:) (L s) where
 instance Additive s => Biproduct (:*:) (L s)
 
 instance Representable r => MonoidalR r (:.:) (L s) where
-  cross :: Obj2 (L s) a b => r (L s a b) -> L s (r :.: a) (r :.: b)
-  cross fs = L (Comp1 . liftR2 unL fs . unComp1)
+  bifunctor :: Obj2 (L s) a b => r (L s a b) -> L s (r :.: a) (r :.: b)
+  bifunctor fs = L (Comp1 . liftR2 unL fs . unComp1)
 
 #if 0
                    fs :: r (L s a b)
         liftR2 unL fs :: r (a s) -> r (b s)
 Comp1 . liftR2 unL fs . unComp1 :: (r :.: a) s -> (r :.: b) s
 
-cross = L . inNew (liftR2 unL)
+bifunctor = L . inNew (liftR2 unL)
 #endif
 
 instance Representable r => CartesianR r (:.:) (L s) where
@@ -51,9 +49,6 @@ instance Representable r => CartesianR r (:.:) (L s) where
   exs = tabulate (\ i -> L (\ (Comp1 as) -> as `index` i))
   dups :: Obj (L s) a => L s a (r :.: a)
   dups = L (Comp1 . pureRep)
-
-instance Representable r => ComonoidalR r (:.:) (L s) where
-  plus = cross
 
 instance (Additive s, Representable r, Eq (Rep r), Foldable r)
       => CocartesianR r (:.:) (L s) where

--- a/src/LinearFunction.hs
+++ b/src/LinearFunction.hs
@@ -33,15 +33,15 @@ instance Additive s => Cocartesian (:*:) (L s) where
 instance Additive s => Biproduct (:*:) (L s)
 
 instance Representable r => MonoidalR r (:.:) (L s) where
-  bifunctor :: Obj2 (L s) a b => r (L s a b) -> L s (r :.: a) (r :.: b)
-  bifunctor fs = L (Comp1 . liftR2 unL fs . unComp1)
+  rmap :: Obj2 (L s) a b => r (L s a b) -> L s (r :.: a) (r :.: b)
+  rmap fs = L (Comp1 . liftR2 unL fs . unComp1)
 
 #if 0
                    fs :: r (L s a b)
         liftR2 unL fs :: r (a s) -> r (b s)
 Comp1 . liftR2 unL fs . unComp1 :: (r :.: a) s -> (r :.: b) s
 
-bifunctor = L . inNew (liftR2 unL)
+rmap = L . inNew (liftR2 unL)
 #endif
 
 instance Representable r => CartesianR r (:.:) (L s) where


### PR DESCRIPTION
Unify `Comonoidal` with `Monoidal`

*   Drop functional dependencies in associated product, coproduct, and exponential.
*   Unify `Comonoidal` with `Monoidal` and `ComonoidalR` with `MonoidalR`.
*   Merge `(***)` and `(+++)` to become `(###)`.
    Merge `cross` and `plus` to become `bifunctor`.
*   Drop some `UndecidableInstances` pragmas.
