### PR TITLE
Deriving via no phantom

### DIFF
--- a/src/Category.hs
+++ b/src/Category.hs
@@ -249,46 +249,46 @@ class BicartesianR r p p k => BiproductR r p k
 
 -- | The 'ViaCartesian' type is designed to be used with `DerivingVia` to derive
 -- `Associative` and `Symmetric` instances using the `Cartesian` operations.
-newtype ViaCartesian p k a b = ViaCartesian (k a b)
-instance Category k => Category (ViaCartesian p k) where
-  type Obj' (ViaCartesian p k) a = Obj k a
+newtype ViaCartesian k a b = ViaCartesian (a `k` b)
+instance Category k => Category (ViaCartesian k) where
+  type Obj' (ViaCartesian k) a = Obj k a
   id = ViaCartesian id
   ViaCartesian g . ViaCartesian f = ViaCartesian (g . f)
-instance Cartesian p k => Monoidal p (ViaCartesian p k) where
+instance Cartesian p k => Monoidal p (ViaCartesian k) where
   f ### g = (f . exl) &&& (g . exr)
-instance (Representable r, CartesianR r p k) => MonoidalR r p (ViaCartesian p k) where
+instance (Representable r, CartesianR r p k) => MonoidalR r p (ViaCartesian k) where
   rmap fs = fork (liftR2 (.) fs exs)
-deriving instance Cartesian p k => Cartesian p (ViaCartesian p k)
-instance (CartesianR r p k, Representable r) => CartesianR r p (ViaCartesian p k) where
+deriving instance Cartesian p k => Cartesian p (ViaCartesian k)
+instance (CartesianR r p k, Representable r) => CartesianR r p (ViaCartesian k) where
   exs = ViaCartesian <$> exs
   dups = ViaCartesian dups
 
-instance Cartesian p k => Associative p (ViaCartesian p k) where
+instance Cartesian p k => Associative p (ViaCartesian k) where
   lassoc = second exl &&& (exr . exr)
   rassoc = (exl . exl) &&& first  exr
-instance Cartesian p k => Symmetric p (ViaCartesian p k) where
+instance Cartesian p k => Symmetric p (ViaCartesian k) where
   swap = exr &&& exl
 
 -- | The 'ViaCocartesian' type is designed to be used with `DerivingVia` to derive
 -- `Associative` and `Symmetric` instances using the `Cocartesian` operations.
-newtype ViaCocartesian co k a b = ViaCocartesian (k a b)
-instance Category k => Category (ViaCocartesian p k) where
-  type Obj' (ViaCocartesian p k) a = Obj k a
+newtype ViaCocartesian k a b = ViaCocartesian (a `k` b)
+instance Category k => Category (ViaCocartesian k) where
+  type Obj' (ViaCocartesian k) a = Obj k a
   id = ViaCocartesian id
   ViaCocartesian g . ViaCocartesian f = ViaCocartesian (g . f)
-instance Cocartesian co k => Monoidal co (ViaCocartesian co k) where
+instance Cocartesian co k => Monoidal co (ViaCocartesian k) where
   f ### g = (inl . f) ||| (inr . g)
-instance (CocartesianR r p k, Representable r) => MonoidalR r p (ViaCocartesian p k) where
+instance (CocartesianR r p k, Representable r) => MonoidalR r p (ViaCocartesian k) where
   rmap fs = join (liftR2 (.) ins fs)
-deriving instance Cocartesian co k => Cocartesian co (ViaCocartesian co k)
-instance (CocartesianR r p k, Representable r) => CocartesianR r p (ViaCocartesian p k) where
+deriving instance Cocartesian co k => Cocartesian co (ViaCocartesian k)
+instance (CocartesianR r p k, Representable r) => CocartesianR r p (ViaCocartesian k) where
   ins = ViaCocartesian <$> ins
   jams = ViaCocartesian jams
 
-instance Cocartesian co k => Associative co (ViaCocartesian co k) where
+instance Cocartesian co k => Associative co (ViaCocartesian k) where
   lassoc = inl.inl ||| (inl.inr ||| inr)
   rassoc = (inl ||| inr.inl) ||| inr.inr
-instance Cocartesian co k => Symmetric co (ViaCocartesian co k) where
+instance Cocartesian co k => Symmetric co (ViaCocartesian k) where
   swap = inr ||| inl
 
 -------------------------------------------------------------------------------
@@ -325,10 +325,10 @@ instance MonoidalClosed (:*) (->) (->) where
   curry   = P.curry
   uncurry = P.uncurry
 
-deriving via (ViaCartesian   (:*) (->)) instance Associative (:*) (->)
-deriving via (ViaCartesian   (:*) (->)) instance Symmetric   (:*) (->)
-deriving via (ViaCocartesian (:+) (->)) instance Associative (:+) (->)
-deriving via (ViaCocartesian (:+) (->)) instance Symmetric   (:+) (->)
+deriving via (ViaCartesian   (->)) instance Associative (:*) (->)
+deriving via (ViaCartesian   (->)) instance Symmetric   (:*) (->)
+deriving via (ViaCocartesian (->)) instance Associative (:+) (->)
+deriving via (ViaCocartesian (->)) instance Symmetric   (:+) (->)
 
 instance Representable r => MonoidalR r Ap (->) where
   rmap rab (Ap ra) = Ap (liftR2 ($) rab ra)

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -10,6 +10,7 @@ module Category where
 import qualified Prelude as P
 import Prelude hiding (id,(.),curry,uncurry)
 import GHC.Types (Constraint)
+import GHC.Exts (Coercible)
 import qualified Control.Arrow as A
 import Data.Monoid (Ap(..))
 import Data.Functor.Rep
@@ -290,6 +291,15 @@ instance Cocartesian co k => Associative co (ViaCocartesian k) where
   rassoc = (inl ||| inr.inl) ||| inr.inr
 instance Cocartesian co k => Symmetric co (ViaCocartesian k) where
   swap = inr ||| inl
+
+-- For deriving via with n-ary products and coproducts.
+-- See https://github.com/conal/linalg/pull/54#discussion_r481393523
+type Representational1' r =
+  ((forall p q. Coercible p q => Coercible (r p) (r q)) :: Constraint)
+
+-- Wrap to avoid impredicativity
+class    Representational1' r => Representational1 r
+instance Representational1' r => Representational1 r
 
 -------------------------------------------------------------------------------
 -- | Function instances

--- a/src/InductiveMatrix.hs
+++ b/src/InductiveMatrix.hs
@@ -147,10 +147,7 @@ pattern Join :: (CocartesianR h p k, Obj2 k f g) => h (k f g) -> k (p h f) g
 pattern Join ms <- (unjoin -> ms) where Join = join
 {-# COMPLETE Join :: L #-}
 
-instance Semiring s => Monoidal (:*:) (L s) where
-  f ### g = (inl . f) :|# (inr . g)
-
--- deriving via (ViaCocartesian (:*:) (L s)) instance Monoidal (:*:) (L s)
+deriving via ViaCocartesian (L s) instance Semiring s => Monoidal (:*:) (L s)
 
 instance (V r, Semiring s) => MonoidalR r (:.:) (L s) where
   rmap fs = ForkL (liftR2 (.) fs exs)

--- a/src/InductiveMatrix.hs
+++ b/src/InductiveMatrix.hs
@@ -2,8 +2,9 @@
 
 {- |
 "Inductive matrices", as in "Type Your Matrices for Great Good: A Haskell
-Library of Typed Matrices and Applications (Functional Pearl)" Armando Santos
-and José N Oliveira (Haskell Symposium 2020) [URL?]. The main differences:
+Library of Typed Matrices and Applications (Functional Pearl)" by Armando Santos
+and José N Oliveira (Haskell Symposium 2020)
+<https://github.com/bolt12/tymfgg-pearl>. The main differences:
 
 - Representable functors rather than their index types (logarithms).
 - Specified via denotational homomorphisms.
@@ -11,7 +12,6 @@ and José N Oliveira (Haskell Symposium 2020) [URL?]. The main differences:
 
 module InductiveMatrix where
 
-import GHC.Exts (Coercible)
 import CatPrelude
 
 import qualified LinearFunction as F
@@ -30,12 +30,7 @@ type V' a = (Representable a, Eq (Rep a))
 class    V' a => V a
 instance V' a => V a
 
--- For deriving via. See https://github.com/conal/linalg/pull/54#discussion_r481393523
-type Representational1 r =
-  ((forall p q. Coercible p q => Coercible (r p) (r q)) :: Constraint)
-
-class    (V r, Representational1 r) => VR r
-instance (V r, Representational1 r) => VR r
+type VR r = (V r, Representational1 r)
 
 -- | Compositional linear map representation.
 data L :: * -> (* -> *) -> (* -> *) -> * where


### PR DESCRIPTION
Following the conversation about wonky `deriving via` [here](https://github.com/conal/linalg/pull/54#discussion_r481393523), I was poking around and noticed that `ViaCartesian` and `ViaCocartesian` had phantom type parameters (product and coproduct respectively). On a lark, I tried removing those parameters, and the result compiled. The previously broken deriving-via `Monoidal` instance in `InductiveMatrix` then started working (after adding `Semiring s`).

The deriving-via `MonoidalR` instance still needs work, due to the representational equality issue also discussed [here](https://github.com/conal/linalg/pull/54#discussion_r481393523).
