### PR TITLE
Add FunctorMatrix

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -59,6 +59,7 @@ library:
     - Category
     - Orphans
     - LinearFunction
+    - FunctorMatrix
     - InductiveMatrix # coming
     - LinAlg          # going
     - CatPrelude

--- a/package.yaml
+++ b/package.yaml
@@ -59,7 +59,7 @@ library:
     - Category
     - Orphans
     - LinearFunction
-    - FunctorMatrix
+    - RowMajor
     - InductiveMatrix # coming
     - LinAlg          # going
     - CatPrelude

--- a/src/CatPrelude.hs
+++ b/src/CatPrelude.hs
@@ -8,7 +8,7 @@ module CatPrelude (
   , module Data.Functor.Rep
   , module GHC.Generics
   , module GHC.Types
-  , Newtype
+  , Newtype(..)
   ) where
 
 import Prelude hiding ((*), (+), id, (.), sum, unzip, curry, uncurry)
@@ -16,7 +16,7 @@ import Prelude hiding ((*), (+), id, (.), sum, unzip, curry, uncurry)
 import Misc
 import Category
 
-import Control.Newtype.Generics (Newtype)
+import Control.Newtype.Generics (Newtype(..))
 import Data.Distributive
 import Data.Functor.Rep
 import GHC.Generics ((:*:)(..), (:+:)(..), (:.:)(..), Generic, Generic1, Par1(..), U1(..))

--- a/src/CatPrelude.hs
+++ b/src/CatPrelude.hs
@@ -8,10 +8,10 @@ module CatPrelude (
   , module Data.Functor.Rep
   , module GHC.Generics
   , module GHC.Types
-  , Newtype(..)
+  , module Control.Newtype.Generics
   ) where
 
-import Prelude hiding ((*), (+), id, (.), sum, unzip, curry, uncurry)
+import Prelude hiding ((*), (+), id, (.), product, sum, unzip, curry, uncurry)
 
 import Misc
 import Category

--- a/src/CatPrelude.hs
+++ b/src/CatPrelude.hs
@@ -8,6 +8,7 @@ module CatPrelude (
   , module Data.Functor.Rep
   , module GHC.Generics
   , module GHC.Types
+  , Newtype
   ) where
 
 import Prelude hiding ((*), (+), id, (.), sum, unzip, curry, uncurry)
@@ -15,6 +16,7 @@ import Prelude hiding ((*), (+), id, (.), sum, unzip, curry, uncurry)
 import Misc
 import Category
 
+import Control.Newtype.Generics (Newtype)
 import Data.Distributive
 import Data.Functor.Rep
 import GHC.Generics ((:*:)(..), (:+:)(..), (:.:)(..), Generic, Generic1, Par1(..), U1(..))

--- a/src/Category.hs
+++ b/src/Category.hs
@@ -157,7 +157,7 @@ cod g = g ^^^ id
 -- The argument order in (^^^) is opposite that of concat.
 
 class (Monoidal p k, Closed e k) => MonoidalClosed p e k where
-  curry   :: Obj3 k a b c => ((a `p` b) `k` c)   -> (a `k` (b `e` c))
+  curry   :: Obj3 k a b c => ((a `p` b) `k` c) -> (a `k` (b `e` c))
   uncurry :: Obj3 k a b c => (a `k` (b `e` c)) -> ((a `p` b) `k` c)
   apply   :: Obj2 k a b => ((a `e` b) `p` a) `k` b
   apply = uncurry id

--- a/src/Category/Isomorphism.hs
+++ b/src/Category/Isomorphism.hs
@@ -88,10 +88,8 @@ joinIso = join :<-> unjoin
 forkIso :: (CartesianR r p k, Obj2 k a b) => r (a `k` b) <-> (a `k` p r b)
 forkIso = fork :<-> unfork
 
-curryIso :: ((a :* b) -> c) <-> (a -> (b -> c))
+curryIso :: (MonoidalClosed p e k, Obj3 k a b c) => ((a `p` b) `k` c) <-> (a `k` (b `e` c))
 curryIso = curry :<-> uncurry
-
--- TODO: generalize curry from (->) to cartesian closed
 
 newIso :: Newtype a => a <-> O a
 newIso = unpack :<-> pack

--- a/src/Category/Isomorphism.hs
+++ b/src/Category/Isomorphism.hs
@@ -114,3 +114,6 @@ type f <--> g = forall a. f a <-> g a
 
 fmapIso :: Functor f => a <-> b -> f a <-> f b
 fmapIso (f :<-> g) = (fmap f :<-> fmap g)
+
+flipIso :: (a -> b -> c) <-> (b -> a -> c)
+flipIso = flip :<-> flip

--- a/src/Category/Isomorphism.hs
+++ b/src/Category/Isomorphism.hs
@@ -115,3 +115,10 @@ fmapIso (f :<-> g) = (fmap f :<-> fmap g)
 
 flipIso :: (a -> b -> c) <-> (b -> a -> c)
 flipIso = flip :<-> flip
+
+distributeIso :: (Representable f, Representable g) => f (g a) <-> g (f a)
+-- distributeIso = inv repIso . fmapIso (inv repIso) . flipIso . fmapIso repIso . repIso
+distributeIso = distribute :<-> distribute
+
+collectIso :: (Representable f, Representable g) => f a <-> b -> f (g a) <-> g b
+collectIso f = fmapIso f . distributeIso

--- a/src/FunctorMatrix.hs
+++ b/src/FunctorMatrix.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+{- |
+"Functor Matrices", or a "matrix" represented by a representable functor of
+representable functors.
+-}
+
+module FunctorMatrix where
+
+import CatPrelude
+
+import qualified LinearFunction as F
+import LinearFunction hiding (L(..))
+import Category.Isomorphism
+
+-------------------------------------------------------------------------------
+-- | Representation and its denotation
+-------------------------------------------------------------------------------
+
+type V' a = (Foldable a, Representable a, Eq (Rep a))
+
+class    V' a => V a
+instance V' a => V a
+
+type VR r = (V r, Representational1 r)
+
+-- | Compositional linear map representation.
+data L s f g where
+  L :: (Representable f, Representable g) => { unL :: g (f s) } -> L s f g
+
+instance LinearMap L where
+  mu = fwd :<-> rev
+    where
+      fwd (L gfs) = F.L $ flip fmap gfs . dot
+      rev (F.L m) = L $ collect m $ unL id
+
+instance Category (L s) where
+  type Obj' (L s) a = (Semiring s, V a)
+  id = L basis
+  L b . L a = L $ flip cotraverse a . dot <$> b
+
+instance (Representable f, Representable g, Semiring s) => Additive (L s f g) where
+  zero = L $ pureRep (pureRep zero)
+  (+)  = pointwise (+)
+
+pointwise :: (Representable f, Representable g) => (a -> b -> c) -> L a f g -> L b f g -> L c f g
+pointwise f (L a) (L b) = L $ liftR2 (liftR2 f) a b
+
+
+instance Semiring s => Cartesian (:*:) (L s) where
+  L gfa &&& L g'fa = L $ gfa :*: g'fa
+  unfork2 (L (x :*: y)) = (L x, L y)
+
+pattern (:&) :: (Cartesian p k, Obj3 k a c d)
+             => (a `k` c) -> (a `k` d) -> (a `k` (c `p` d))
+pattern f :& g <- (unfork2 -> (f,g)) where (:&) = (&&&)
+{-# COMPLETE (:&) :: L #-}
+
+instance Semiring s => Cocartesian (:*:) (L s) where
+  L gfa ||| L gf'a = L $ liftR2 (:*:) gfa gf'a
+  unjoin2 (L l) = (L $ fstP <$> l, L $ sndP <$> l)
+    where
+      fstP (x :*: _) = x
+      sndP (_ :*: y) = y
+
+pattern (:|) :: (Cocartesian co k, Obj3 k a b c)
+             => (a `k` c) -> (b `k` c) -> ((a `co` b) `k` c)
+pattern f :| g <- (unjoin2 -> (f,g)) where (:|) = (|||)
+{-# COMPLETE (:|) :: L #-}
+
+instance (VR r, Semiring s) => CartesianR r (:.:) (L s) where
+  fork   = L . Comp1 . fmap unL
+  unfork = fmap L . unComp1 . unL
+
+pattern Fork :: (CartesianR h p k, Obj2 k f g) => h (k f g) -> k f (p h g)
+pattern Fork ms <- (unfork -> ms) where Fork = fork
+{-# COMPLETE Fork :: L #-}
+
+instance (VR r, Semiring s) => CocartesianR r (:.:) (L s) where
+  join   = L . fmap Comp1 . distribute . fmap unL
+  unjoin = fmap L . distribute . fmap unComp1 . unL
+
+pattern Join :: (CocartesianR h p k, Obj2 k f g) => h (k f g) -> k (p h f) g
+pattern Join ms <- (unjoin -> ms) where Join = join
+{-# COMPLETE Join :: L #-}
+
+
+instance Semiring s => Biproduct (:*:) (L s)
+instance (VR r, Semiring s) => BiproductR r (:.:) (L s)
+
+deriving via ViaCartesian (L s) instance Semiring s => Monoidal (:*:) (L s)
+
+deriving via ViaCartesian (L s)
+  instance (VR r, Semiring s) => MonoidalR r (:.:) (L s)

--- a/src/FunctorMatrix.hs
+++ b/src/FunctorMatrix.hs
@@ -12,9 +12,6 @@ import CatPrelude
 import LinearFunction hiding (L(..))
 import Category.Isomorphism
 
--------------------------------------------------------------------------------
--- | Representation and its denotation
--------------------------------------------------------------------------------
 
 type V' a = (Foldable a, Representable a, Eq (Rep a))
 
@@ -30,7 +27,7 @@ newtype L (s :: *) (f :: * -> *) (g :: * -> *) = L { unL :: g (f s) }
 instance Newtype (L s f g)
 
 instance LinearMap L where
-  mu = inv newIso . fmapIso (inv repIso) . flipIso . repIso . fmapIso dotIso . newIso
+  mu = inv newIso . distributeIso . fmapIso dotIso . newIso
   --                          L s f g
   -- newIso               ==> g (f s)
   -- fmapIso dotIso       ==> g (f s -> s)
@@ -47,19 +44,100 @@ instance LinearMap L where
 instance Category (L s) where
   type Obj' (L s) a = (Semiring s, V a)
   id = L basis
-  L b . L a = L $ flip cotraverse a . dot <$> b
+  b . a
+  -- Trying to prove:
+  --  L b . L a = L $ fmap (flip fmap (distribute a) . dot) b
+  -- which is synonymous with
+  --  L b . L a = L $ flip cotraverse a . dot <$> b
+  --
+  -- Let's start from the definition as given by the isomorphism with linear maps.
+  -- b . a = isoRev mu $ isoFwd mu b . isoFwd mu a
+  -- = L $ fmap dot' $ distribute $ F.unL
+  --   $ (F.L $ distribute $ fmap dot $ unL b)
+  --   . (F.L $ distribute $ fmap dot $ unL a)
+  --
+  -- By definition of (.) on F.L
+  -- = L $ fmap dot' $ distribute $ F.unL
+  --   $ F.L $ (distribute $ fmap dot $ unL b)
+  --         . (distribute $ fmap dot $ unL a)
+  --
+  -- F.unL . F.L = id
+  -- = L $ fmap dot' $ distribute
+  --     $ (distribute $ fmap dot $ unL b)
+  --     . (distribute $ fmap dot $ unL a)
+  --
+  -- By definition of (.) and eta expansion
+  -- = L $ fmap dot' $ distribute
+  --     $ \x -> (distribute $ fmap dot $ unL b)
+  --            ((distribute $ fmap dot $ unL a) x)
+  --
+  -- Recognize that (fmap dot $ unL b) :: h (g s -> s).
+  -- Thus, `distribute (fmap dot $ unL b)` uses the `(e ->)` instance, which we unroll.
+  -- Likewise with (distribute $ fmap dot $ unL a).
+  -- = L $ fmap dot' $ distribute
+  --     $ \x -> (\y -> fmap ($y) (fmap dot $ unL b))
+  --            ((\z -> fmap ($z) (fmap dot $ unL a)) x)
+  --
+  -- fmap f (fmap g $ x) = fmap f . fmap g $ x, and
+  -- fmap f . fmap g = fmap (f . g)
+  -- = L $ fmap dot' $ distribute
+  --     $ \x -> (\y -> fmap (flip dot y) (unL b))
+  --            ((\z -> fmap (flip dot z) (unL a)) x)
+  --
+  -- Two rounds of eta reduction.
+  -- = L $ fmap dot' $ distribute
+  --     $ \x -> fmap (flip dot (fmap (flip dot x) (unL a))) (unL b)
+  --
+  -- flip dot == dot
+  -- = L $ fmap dot' $ distribute
+  --     $ \x -> fmap (dot (fmap (dot x) (unL a))) (unL b)
+  --
+  -- pointfree
+   = L $ fmap dot' $ distribute
+       $ flip fmap (unL b) . dot . flip fmap (unL a) . dot
+
+
+-- How can I bring dot and dot' together to form an identity?
+-- How do I deal with distribute?
+--
+-- Are either of these statements true?
+-- distribute (g . f) ?= fmap (. f) (distribute g)
+-- distribute (\x -> fmap (g x) y) ?= fmap (distribute g) y
+
+
+
+
+
+
+
+
+
 
 instance (Representable f, Representable g, Semiring s) => Additive (L s f g) where
-  zero = L $ pureRep (pureRep zero)
-  (+)  = pointwise (+)
+  zero = pureL zero
+  (+)  = pointwise2 (+)
 
-pointwise :: (Representable f, Representable g) => (a -> b -> c) -> L a f g -> L b f g -> L c f g
-pointwise f (L a) (L b) = L $ liftR2 (liftR2 f) a b
+pureL :: (Representable f, Representable g) => a -> L a f g
+pureL = pack . pureRep . pureRep
 
+pointwise2 :: (Representable f, Representable g) => (a -> b -> c) -> L a f g -> L b f g -> L c f g
+pointwise2 = inNew2 . liftR2 . liftR2
+
+fork2LIso :: (L s a c :* L s a d) <-> L s a (c :*: d)
+fork2LIso = inv newIso . inv newIso . (newIso ### newIso)
+
+join2LIso :: (Representable a, Representable c, Representable d) => (L s c a :* L s d a) <-> L s (c :*: d) a
+join2LIso = inv newIso . distributeIso . inv newIso . (distributeIso . newIso ### distributeIso . newIso)
+
+forkLIso :: Representable r => r (L s a b) <-> L s a (r :.: b)
+forkLIso = inv newIso . inv newIso . fmapIso newIso
+
+joinLIso :: (Representable b, Representable r) => r (L s a b) <-> L s (r :.: a) b
+joinLIso = inv newIso . collectIso (inv newIso) . fmapIso newIso
 
 instance Semiring s => Cartesian (:*:) (L s) where
-  L gfa &&& L g'fa = L $ gfa :*: g'fa
-  unfork2 (L (gfa :*: g'fa)) = (L gfa, L g'fa)
+  (&&&)   = curry $ isoFwd fork2LIso
+  unfork2 = isoRev fork2LIso
 
 pattern (:&) :: (Cartesian p k, Obj3 k a c d)
              => (a `k` c) -> (a `k` d) -> (a `k` (c `p` d))
@@ -67,11 +145,8 @@ pattern f :& g <- (unfork2 -> (f,g)) where (:&) = (&&&)
 {-# COMPLETE (:&) :: L #-}
 
 instance Semiring s => Cocartesian (:*:) (L s) where
-  L gfa ||| L gf'a = L $ liftR2 (:*:) gfa gf'a
-  unjoin2 (L l) = (L $ fstP <$> l, L $ sndP <$> l)
-    where
-      fstP (x :*: _) = x
-      sndP (_ :*: y) = y
+  (|||)   = curry $ isoFwd join2LIso
+  unjoin2 = isoRev join2LIso
 
 pattern (:|) :: (Cocartesian co k, Obj3 k a b c)
              => (a `k` c) -> (b `k` c) -> ((a `co` b) `k` c)
@@ -79,16 +154,16 @@ pattern f :| g <- (unjoin2 -> (f,g)) where (:|) = (|||)
 {-# COMPLETE (:|) :: L #-}
 
 instance (VR r, Semiring s) => CartesianR r (:.:) (L s) where
-  fork   = L . Comp1 . fmap unL
-  unfork = fmap L . unComp1 . unL
+  fork   = isoFwd forkLIso
+  unfork = isoRev forkLIso
 
 pattern Fork :: (CartesianR h p k, Obj2 k f g) => h (k f g) -> k f (p h g)
 pattern Fork ms <- (unfork -> ms) where Fork = fork
 {-# COMPLETE Fork :: L #-}
 
 instance (VR r, Semiring s) => CocartesianR r (:.:) (L s) where
-  join   = L . cotraverse Comp1 . fmap unL
-  unjoin = fmap L . collect unComp1 . unL
+  join   = isoFwd joinLIso
+  unjoin = isoRev joinLIso
 
 pattern Join :: (CocartesianR h p k, Obj2 k f g) => h (k f g) -> k (p h f) g
 pattern Join ms <- (unjoin -> ms) where Join = join

--- a/src/LinearFunction.hs
+++ b/src/LinearFunction.hs
@@ -11,6 +11,9 @@ import Category.Isomorphism
 
 -- | Linear functions
 newtype L (s :: *) a b = L { unL :: a s -> b s }
+  deriving (Generic)
+
+instance Newtype (L s a b)
 
 instance Category (L s) where
   type Obj' (L s) a = Representable a


### PR DESCRIPTION
This module adds matrices of the form `g (f s)` where `g` and `f` are representable functors.

There's one weird part of the definition, which is that I defined the `Obj'` type as:
```haskell
type Obj' (L s) a = (Semiring s, V a)
```
If I didn't include `Semiring s` here, then I didn't have that information when I needed it in the `LinearMap` instance.  That said, by including it in `Obj'`, I no longer need to have it in the context of the `Category` instance itself.